### PR TITLE
Fixed style duplication when saving with new URL

### DIFF
--- a/stylebot/js/options-styles.js
+++ b/stylebot/js/options-styles.js
@@ -230,6 +230,7 @@ Options.styles = {
         }
 
         backgroundPage.cache.styles.create(url, rules);
+        if (originalUrl) backgroundPage.cache.styles.delete(originalUrl);
         return true;
       }
 


### PR DESCRIPTION
When editing a style through the options menu and changing the URL it applies to, there will be 2 styles after refreshing the options page.
One style will have the old URL, the other the new URL.

The parameter `originalUrl` was originally ignored in `Types.save`, so I assumed this was the right thing to do.
