### PR TITLE
Use the best monospace font for every OS

### DIFF
--- a/stylebot/js/widget.basic.js
+++ b/stylebot/js/widget.basic.js
@@ -33,7 +33,7 @@ stylebot.widget.basic = {
         'Helvetica, Arial, sans-serif',
         'Palatino, Georgia, serif',
         '"Lucida Grande", Verdana, sans-serif',
-        '"Ubuntu Mono", Monaco, Inconsolata, monospace'
+        'Consolas, Monaco, "Ubuntu Mono", monospace'
       ],
       el: null
     },


### PR DESCRIPTION
Hello again :)

I gave it another thought and have come up with this:

Users of all major operating systems must get the best fonts for theis OS:
1. Windows - Consolas
2. Mac OS  - Monaco
3. Linux   - Ubuntu Mono

Of course there are more good monospace fonts in every OS and in general. But if we include them all, the string will be too long :) I picked what I believe are the best fonts; the `monospace` fallback should cover the rest (users can pick their favorite monospace font in their browser settings).

I hope that this version is better.

Thanks!
