### PR TITLE
Fixed styles being deleted if URL unchanged

### DIFF
--- a/stylebot/js/options-styles.js
+++ b/stylebot/js/options-styles.js
@@ -228,9 +228,10 @@ Options.styles = {
           Options.modal.showSyntaxError(rules['error']);
           return false;
         }
+        debugger;
 
         backgroundPage.cache.styles.create(url, rules);
-        if (originalUrl) backgroundPage.cache.styles.delete(originalUrl);
+        if (originalUrl && originalUrl!=url) backgroundPage.cache.styles.delete(originalUrl);
         return true;
       }
 


### PR DESCRIPTION
My previous PR for this spot would delete the style if the URL was not changed. This fixes this fatal mistake.
