### PR TITLE
fixes #654 - Give style editor position to enable z-index

### DIFF
--- a/src/options/components/styles/StyleEditor.vue
+++ b/src/options/components/styles/StyleEditor.vue
@@ -74,6 +74,7 @@ export default Vue.extend({
 
 <style lang="scss">
 .style-editor {
+  position: relative;
   z-index: 100000;
 }
 


### PR DESCRIPTION
The editor had a z-index but it wasn't being respected because it wasn't positioned.  Given a position it can now be placed over the other elements of the page

![image](https://user-images.githubusercontent.com/3536716/133907248-f77c90b4-4a51-452e-aaed-adbc3a62b499.png)
