### PR TITLE
Eliminate remaining flash of unstyled content

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  root: true,
   parser: "vue-eslint-parser",
 
   parserOptions: {

--- a/src/inject-css/__tests__/apply-state.test.ts
+++ b/src/inject-css/__tests__/apply-state.test.ts
@@ -1,0 +1,94 @@
+import { CachedState } from '../cache';
+
+jest.mock('@stylebot/css');
+jest.mock('@stylebot/readability');
+
+describe('applyState', () => {
+  let css: typeof import('@stylebot/css');
+  let readability: typeof import('@stylebot/readability');
+  let applyState: typeof import('../apply-state').applyState;
+
+  beforeEach(() => {
+    // appliedUrls is module-level state, tracking what's currently
+    // injected across calls — reset the module so each test starts clean.
+    jest.resetModules();
+
+    css = require('@stylebot/css');
+    readability = require('@stylebot/readability');
+    ({ applyState } = require('../apply-state'));
+
+    (css.injectCSSIntoDocument as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it('injects only the enabled styles', async () => {
+    const state: CachedState = {
+      styles: [
+        { url: 'a', css: '.a{}', enabled: true },
+        { url: 'b', css: '.b{}', enabled: false },
+      ],
+      readability: false,
+    };
+
+    await applyState(state);
+
+    expect(css.injectCSSIntoDocument).toHaveBeenCalledTimes(1);
+    expect(css.injectCSSIntoDocument).toHaveBeenCalledWith('.a{}', 'a');
+  });
+
+  it('applies readability when the state calls for it', async () => {
+    await applyState({ styles: [], readability: true });
+
+    expect(readability.apply).toHaveBeenCalledTimes(1);
+    expect(readability.remove).not.toHaveBeenCalled();
+  });
+
+  it('removes readability when the state does not call for it', async () => {
+    await applyState({ styles: [], readability: false });
+
+    expect(readability.remove).toHaveBeenCalledTimes(1);
+    expect(readability.apply).not.toHaveBeenCalled();
+  });
+
+  it('removes a stylesheet that is no longer enabled on a later call', async () => {
+    await applyState({
+      styles: [{ url: 'a', css: '.a{}', enabled: true }],
+      readability: false,
+    });
+
+    await applyState({ styles: [], readability: false });
+
+    expect(css.removeCSSFromDocument).toHaveBeenCalledWith('a');
+  });
+
+  it('removes a stylesheet that was disabled on a later call', async () => {
+    await applyState({
+      styles: [{ url: 'a', css: '.a{}', enabled: true }],
+      readability: false,
+    });
+
+    await applyState({
+      styles: [{ url: 'a', css: '.a{}', enabled: false }],
+      readability: false,
+    });
+
+    expect(css.removeCSSFromDocument).toHaveBeenCalledWith('a');
+  });
+
+  it('does not remove a stylesheet that remains enabled', async () => {
+    await applyState({
+      styles: [{ url: 'a', css: '.a{}', enabled: true }],
+      readability: false,
+    });
+
+    await applyState({
+      styles: [{ url: 'a', css: '.a{updated}', enabled: true }],
+      readability: false,
+    });
+
+    expect(css.removeCSSFromDocument).not.toHaveBeenCalled();
+    expect(css.injectCSSIntoDocument).toHaveBeenLastCalledWith(
+      '.a{updated}',
+      'a'
+    );
+  });
+});

--- a/src/inject-css/__tests__/cache.test.ts
+++ b/src/inject-css/__tests__/cache.test.ts
@@ -1,0 +1,60 @@
+import { CachedState, readCache, writeCache } from '../cache';
+
+const CACHE_KEY = 'stylebot-cache';
+
+const sampleState: CachedState = {
+  styles: [{ url: 'https://example.com', css: 'a{color:red}', enabled: true }],
+  readability: false,
+};
+
+describe('cache', () => {
+  afterEach(() => {
+    localStorage.clear();
+    jest.restoreAllMocks();
+  });
+
+  describe('readCache', () => {
+    it('returns null when nothing is cached', () => {
+      expect(readCache()).toBeNull();
+    });
+
+    it('returns the parsed cache when present', () => {
+      localStorage.setItem(CACHE_KEY, JSON.stringify(sampleState));
+
+      expect(readCache()).toEqual(sampleState);
+    });
+
+    it('returns null for corrupt JSON instead of throwing', () => {
+      localStorage.setItem(CACHE_KEY, '{not valid json');
+
+      expect(() => readCache()).not.toThrow();
+      expect(readCache()).toBeNull();
+    });
+
+    it('returns null if localStorage.getItem throws', () => {
+      jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+        throw new Error('blocked');
+      });
+
+      expect(readCache()).toBeNull();
+    });
+  });
+
+  describe('writeCache', () => {
+    it('persists the state as JSON', () => {
+      writeCache(sampleState);
+
+      expect(JSON.parse(localStorage.getItem(CACHE_KEY) as string)).toEqual(
+        sampleState
+      );
+    });
+
+    it('does not throw if localStorage.setItem fails', () => {
+      jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('quota exceeded');
+      });
+
+      expect(() => writeCache(sampleState)).not.toThrow();
+    });
+  });
+});

--- a/src/inject-css/__tests__/hide-page.test.ts
+++ b/src/inject-css/__tests__/hide-page.test.ts
@@ -1,0 +1,36 @@
+import { hidePage, revealPage } from '../hide-page';
+
+const HIDE_STYLE_ID = 'stylebot-hide-page';
+
+describe('hide-page', () => {
+  afterEach(() => {
+    document.getElementById(HIDE_STYLE_ID)?.remove();
+  });
+
+  describe('hidePage', () => {
+    it('appends a style hiding the page to the document', () => {
+      hidePage();
+
+      const style = document.getElementById(HIDE_STYLE_ID);
+
+      expect(style).not.toBeNull();
+      expect(style?.tagName).toBe('STYLE');
+      expect(style?.textContent).toContain('visibility: hidden');
+      expect(style?.parentElement).toBe(document.documentElement);
+    });
+  });
+
+  describe('revealPage', () => {
+    it('removes the hiding style', () => {
+      hidePage();
+      revealPage();
+
+      expect(document.getElementById(HIDE_STYLE_ID)).toBeNull();
+    });
+
+    it('does nothing if the page was never hidden', () => {
+      expect(() => revealPage()).not.toThrow();
+      expect(document.getElementById(HIDE_STYLE_ID)).toBeNull();
+    });
+  });
+});

--- a/src/inject-css/__tests__/index.test.ts
+++ b/src/inject-css/__tests__/index.test.ts
@@ -1,0 +1,142 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+jest.mock('../apply-state');
+jest.mock('../cache');
+jest.mock('../hide-page');
+jest.mock('@stylebot/styles');
+
+const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0));
+
+describe('inject-css run()', () => {
+  let applyStateModule: typeof import('../apply-state');
+  let cacheModule: typeof import('../cache');
+  let hidePageModule: typeof import('../hide-page');
+  let stylesModule: typeof import('@stylebot/styles');
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    applyStateModule = require('../apply-state');
+    cacheModule = require('../cache');
+    hidePageModule = require('../hide-page');
+    stylesModule = require('@stylebot/styles');
+
+    (applyStateModule.applyState as jest.Mock).mockResolvedValue(undefined);
+
+    (global as any).chrome = {
+      storage: { local: { get: jest.fn() } },
+    };
+  });
+
+  const load = (storedItems: Record<string, unknown>) => {
+    (
+      (global as any).chrome.storage.local.get as jest.Mock
+    ).mockImplementation((_key: string, callback: (items: unknown) => void) =>
+      callback(storedItems)
+    );
+
+    require('../index');
+  };
+
+  it('hides the page and applies the fresh state when there is no cache', async () => {
+    (cacheModule.readCache as jest.Mock).mockReturnValue(null);
+    (stylesModule.getStylesForPage as jest.Mock).mockReturnValue({
+      styles: [{ url: 'a', css: '.a{}', enabled: true }],
+      defaultStyle: undefined,
+    });
+
+    load({ styles: {} });
+    await flushPromises();
+
+    const expectedState = {
+      styles: [{ url: 'a', css: '.a{}', enabled: true }],
+      readability: false,
+    };
+
+    expect(hidePageModule.hidePage).toHaveBeenCalledTimes(1);
+    expect(applyStateModule.applyState).toHaveBeenCalledWith(expectedState);
+    expect(cacheModule.writeCache).toHaveBeenCalledWith(expectedState);
+    expect(hidePageModule.revealPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies the cache immediately, without hiding, when there is one', async () => {
+    const cached = {
+      styles: [{ url: 'a', css: '.a{}', enabled: true }],
+      readability: false,
+    };
+
+    (cacheModule.readCache as jest.Mock).mockReturnValue(cached);
+    (stylesModule.getStylesForPage as jest.Mock).mockReturnValue({
+      styles: [{ url: 'a', css: '.a{}', enabled: true }],
+      defaultStyle: undefined,
+    });
+
+    load({ styles: {} });
+
+    expect(hidePageModule.hidePage).not.toHaveBeenCalled();
+    expect(applyStateModule.applyState).toHaveBeenCalledWith(cached);
+  });
+
+  it('does not re-apply when the fresh state matches the cache', async () => {
+    const cached = {
+      styles: [{ url: 'a', css: '.a{}', enabled: true }],
+      readability: false,
+    };
+
+    (cacheModule.readCache as jest.Mock).mockReturnValue(cached);
+    (stylesModule.getStylesForPage as jest.Mock).mockReturnValue({
+      styles: [{ url: 'a', css: '.a{}', enabled: true }],
+      defaultStyle: undefined,
+    });
+
+    load({ styles: {} });
+    await flushPromises();
+
+    // Only the initial cache-hit application — nothing patched afterwards.
+    expect(applyStateModule.applyState).toHaveBeenCalledTimes(1);
+    expect(hidePageModule.revealPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('patches to the fresh state when it differs from a stale cache', async () => {
+    const cached = {
+      styles: [{ url: 'a', css: '.a{old}', enabled: true }],
+      readability: false,
+    };
+
+    (cacheModule.readCache as jest.Mock).mockReturnValue(cached);
+    (stylesModule.getStylesForPage as jest.Mock).mockReturnValue({
+      styles: [{ url: 'a', css: '.a{new}', enabled: true }],
+      defaultStyle: undefined,
+    });
+
+    load({ styles: {} });
+    await flushPromises();
+
+    const freshState = {
+      styles: [{ url: 'a', css: '.a{new}', enabled: true }],
+      readability: false,
+    };
+
+    expect(applyStateModule.applyState).toHaveBeenNthCalledWith(1, cached);
+    expect(applyStateModule.applyState).toHaveBeenNthCalledWith(
+      2,
+      freshState
+    );
+    expect(cacheModule.writeCache).toHaveBeenCalledWith(freshState);
+  });
+
+  it('reads readability off the matched default style', async () => {
+    (cacheModule.readCache as jest.Mock).mockReturnValue(null);
+    (stylesModule.getStylesForPage as jest.Mock).mockReturnValue({
+      styles: [],
+      defaultStyle: { url: '*', readability: true },
+    });
+
+    load({ styles: {} });
+    await flushPromises();
+
+    expect(applyStateModule.applyState).toHaveBeenCalledWith({
+      styles: [],
+      readability: true,
+    });
+  });
+});

--- a/src/inject-css/apply-state.ts
+++ b/src/inject-css/apply-state.ts
@@ -1,0 +1,36 @@
+import { injectCSSIntoDocument, removeCSSFromDocument } from '@stylebot/css';
+import {
+  apply as applyReadability,
+  remove as removeReadability,
+} from '@stylebot/readability';
+
+import { CachedState } from './cache';
+
+// Tracks which stylesheets are currently injected so a later call (once the
+// real storage read resolves) can remove any that are no longer enabled.
+let appliedUrls = new Set<string>();
+
+export const applyState = (state: CachedState): Promise<void> => {
+  const enabled = state.styles.filter(style => style.enabled);
+  const nextUrls = new Set(enabled.map(style => style.url));
+
+  appliedUrls.forEach(url => {
+    if (!nextUrls.has(url)) {
+      removeCSSFromDocument(url);
+    }
+  });
+
+  const injections = enabled.map(style =>
+    injectCSSIntoDocument(style.css, style.url)
+  );
+
+  return Promise.all(injections).then(() => {
+    appliedUrls = nextUrls;
+
+    if (state.readability) {
+      applyReadability();
+    } else {
+      removeReadability();
+    }
+  });
+};

--- a/src/inject-css/cache.ts
+++ b/src/inject-css/cache.ts
@@ -1,12 +1,5 @@
-// chrome.storage has no synchronous equivalent, but localStorage does — so
-// the last-applied result is cached here and reapplied synchronously before
-// anything else runs, closing the flash-of-unstyled-content gap entirely on
-// repeat visits. See index.ts for how a stale or missing cache is handled.
-//
-// One entry per origin (localStorage is already origin-scoped), rather than
-// per exact URL, to keep this bounded. The trade-off: a page whose URL
-// pattern differs from the last-cached page on the same origin may briefly
-// show that other pattern's CSS before this run's storage check corrects it.
+// localStorage is readable synchronously (chrome.storage isn't), so the
+// last-applied result is cached here, one entry per origin.
 const CACHE_KEY = 'stylebot-cache';
 
 export type CachedStyle = { url: string; css: string; enabled: boolean };

--- a/src/inject-css/cache.ts
+++ b/src/inject-css/cache.ts
@@ -1,0 +1,35 @@
+// chrome.storage has no synchronous equivalent, but localStorage does — so
+// the last-applied result is cached here and reapplied synchronously before
+// anything else runs, closing the flash-of-unstyled-content gap entirely on
+// repeat visits. See index.ts for how a stale or missing cache is handled.
+//
+// One entry per origin (localStorage is already origin-scoped), rather than
+// per exact URL, to keep this bounded. The trade-off: a page whose URL
+// pattern differs from the last-cached page on the same origin may briefly
+// show that other pattern's CSS before this run's storage check corrects it.
+const CACHE_KEY = 'stylebot-cache';
+
+export type CachedStyle = { url: string; css: string; enabled: boolean };
+
+export type CachedState = {
+  styles: Array<CachedStyle>;
+  readability: boolean;
+};
+
+export const readCache = (): CachedState | null => {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+};
+
+export const writeCache = (state: CachedState): void => {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify(state));
+  } catch {
+    // localStorage may be unavailable (e.g. blocked by the page); the next
+    // load will simply fall back to the hide-until-ready path again.
+  }
+};

--- a/src/inject-css/hide-page.ts
+++ b/src/inject-css/hide-page.ts
@@ -1,0 +1,21 @@
+const HIDE_PAGE_STYLE_ID = 'stylebot-hide-page';
+
+export const hidePage = (): void => {
+  const style = document.createElement('style');
+
+  style.setAttribute('id', HIDE_PAGE_STYLE_ID);
+  style.appendChild(
+    document.createTextNode('html { visibility: hidden !important; }')
+  );
+
+  document.documentElement.appendChild(style);
+};
+
+// No-op if the page was never hidden, so this is safe to call unconditionally.
+export const revealPage = (): void => {
+  const style = document.getElementById(HIDE_PAGE_STYLE_ID);
+
+  if (style) {
+    style.remove();
+  }
+};

--- a/src/inject-css/index.ts
+++ b/src/inject-css/index.ts
@@ -1,25 +1,7 @@
 /**
- * This content script injects any custom style for the page (if it exists)
- * as soon as the document starts loading.
- *
- * Styles are read directly from chrome.storage.local instead of via
- * chrome.runtime.sendMessage to the background service worker. The service
- * worker can be asleep when a page starts loading, and waking it up (plus
- * the round trip) is slow enough to cause a visible flash of unstyled
- * content. chrome.storage.local is handled by the browser itself and
- * doesn't require the service worker to be running.
- *
- * Reading storage is still asynchronous, so the page keeps parsing and can
- * paint before the style is injected. cache.ts caches the last-applied
- * result in localStorage, which is readable synchronously, and reapplies it
- * before anything else runs — closing the gap entirely on repeat visits.
- * The only case that still needs hide-page.ts's hide-until-ready fallback
- * is a page with no cache yet (first visit, or right after editing the
- * style that applies to it).
- *
- * chrome.storage.local.get is still consulted on every load, cache hit or
- * not, to catch styles that changed since the cache was written; if the
- * result differs, the applied CSS is patched in place and the cache updated.
+ * Injects custom CSS for the page as soon as it starts loading. Applies the
+ * localStorage cache (cache.ts) immediately if there is one, otherwise hides
+ * the page (hide-page.ts) until chrome.storage.local.get resolves.
  */
 import { getStylesForPage } from '@stylebot/styles';
 import { StyleMap } from '@stylebot/types';
@@ -28,9 +10,8 @@ import { applyState } from './apply-state';
 import { CachedState, readCache, writeCache } from './cache';
 import { hidePage, revealPage } from './hide-page';
 
-// Fallback in case storage read (or, for an `@import` style, the background
-// service worker round trip in getCssWithExpandedImports) stalls or fails —
-// real completion almost always wins the race and reveals sooner than this.
+// Fallback if the storage read (or an @import fetch) stalls — real
+// completion almost always wins the race and reveals sooner.
 const REVEAL_TIMEOUT_MS = 150;
 
 const run = () => {

--- a/src/inject-css/index.ts
+++ b/src/inject-css/index.ts
@@ -8,13 +8,42 @@
  * the round trip) is slow enough to cause a visible flash of unstyled
  * content. chrome.storage.local is handled by the browser itself and
  * doesn't require the service worker to be running.
+ *
+ * Reading storage is still asynchronous, so the page keeps parsing and can
+ * paint before the style is injected. cache.ts caches the last-applied
+ * result in localStorage, which is readable synchronously, and reapplies it
+ * before anything else runs — closing the gap entirely on repeat visits.
+ * The only case that still needs hide-page.ts's hide-until-ready fallback
+ * is a page with no cache yet (first visit, or right after editing the
+ * style that applies to it).
+ *
+ * chrome.storage.local.get is still consulted on every load, cache hit or
+ * not, to catch styles that changed since the cache was written; if the
+ * result differs, the applied CSS is patched in place and the cache updated.
  */
-import { injectCSSIntoDocument } from '@stylebot/css';
-import { apply as applyReadability } from '@stylebot/readability';
 import { getStylesForPage } from '@stylebot/styles';
 import { StyleMap } from '@stylebot/types';
 
+import { applyState } from './apply-state';
+import { CachedState, readCache, writeCache } from './cache';
+import { hidePage, revealPage } from './hide-page';
+
+// Fallback in case storage read (or, for an `@import` style, the background
+// service worker round trip in getCssWithExpandedImports) stalls or fails —
+// real completion almost always wins the race and reveals sooner than this.
+const REVEAL_TIMEOUT_MS = 150;
+
 const run = () => {
+  const cached = readCache();
+
+  if (cached) {
+    applyState(cached);
+  } else {
+    hidePage();
+  }
+
+  const revealTimeout = setTimeout(revealPage, REVEAL_TIMEOUT_MS);
+
   chrome.storage.local.get('styles', items => {
     const allStyles: StyleMap = items['styles'] || {};
     const { styles, defaultStyle } = getStylesForPage(
@@ -23,15 +52,23 @@ const run = () => {
       true
     );
 
-    styles.forEach(style => {
-      if (style.enabled) {
-        injectCSSIntoDocument(style.css, style.url);
-      }
-    });
+    const freshState: CachedState = {
+      styles: styles.map(({ url, css, enabled }) => ({ url, css, enabled })),
+      readability: Boolean(defaultStyle && defaultStyle.readability),
+    };
 
-    if (defaultStyle && defaultStyle.readability) {
-      applyReadability();
+    const finish = () => {
+      writeCache(freshState);
+      clearTimeout(revealTimeout);
+      revealPage();
+    };
+
+    if (cached && JSON.stringify(cached) === JSON.stringify(freshState)) {
+      finish();
+      return;
     }
+
+    applyState(freshState).then(finish);
   });
 };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,12 +16,27 @@ const getOutputPath = () =>
     ? `${__dirname}/${process.env.BROWSER}-dist`
     : `${__dirname}/dist`;
 
-// Writes a marker file after each error-free build, so tools outside webpack
-// (e.g. scripts/launch-chrome.mjs) know exactly when a build is ready.
+// Writes a marker file once every compiler has produced an error-free build,
+// so tools outside webpack (e.g. scripts/launch-chrome.mjs) never see it
+// before manifest.json and all bundles exist.
+const compilersDone = {};
+
 class WriteBuildMarkerPlugin {
+  constructor(compilerKey) {
+    this.compilerKey = compilerKey;
+  }
+
   apply(compiler) {
+    compilersDone[this.compilerKey] = false;
+
     compiler.hooks.done.tap('WriteBuildMarkerPlugin', stats => {
       if (stats.hasErrors()) {
+        return;
+      }
+
+      compilersDone[this.compilerKey] = true;
+
+      if (!Object.values(compilersDone).every(Boolean)) {
         return;
       }
 
@@ -133,7 +148,7 @@ const config = {
 
   plugins: [
     new ProgressBarPlugin(),
-    new WriteBuildMarkerPlugin(),
+    new WriteBuildMarkerPlugin('client'),
     new VueLoaderPlugin(),
     new MiniCssExtractPlugin({
       filename: '[name].css',
@@ -258,7 +273,7 @@ const backgroundPageConfig = {
     'background/index': './background/index.ts',
   },
   plugins: [
-    new WriteBuildMarkerPlugin(),
+    new WriteBuildMarkerPlugin('background'),
     new webpack.DefinePlugin({
       global: 'this',
     }),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,9 +16,8 @@ const getOutputPath = () =>
     ? `${__dirname}/${process.env.BROWSER}-dist`
     : `${__dirname}/dist`;
 
-// Writes a marker file once every compiler has produced an error-free build,
-// so tools outside webpack (e.g. scripts/launch-chrome.mjs) never see it
-// before manifest.json and all bundles exist.
+// Writes a marker once every compiler has built successfully, so tools like
+// scripts/launch-chrome.mjs never see it before manifest.json exists.
 const compilersDone = {};
 
 class WriteBuildMarkerPlugin {


### PR DESCRIPTION
## Summary
- Hide the page synchronously the instant the content script runs, revealing it only once the real style is applied (or a short fallback timeout) — closes the gap that reading `chrome.storage.local` (#833) left, since that read is still asynchronous.
- Cache the resolved CSS in the page's own `localStorage`, which is readable synchronously, so repeat visits apply instantly with no hiding needed. `chrome.storage.local` is still checked in the background every load and patches the CSS in place if it changed.
- Fix a build-marker race in `webpack.config.js`: the background and client compilers finish independently under `--watch`, and the marker could be written before `manifest.json` existed, breaking the local dev workflow.
- Add `root: true` to `.eslintrc.js` so lint doesn't pick up a parent checkout's config when run from a nested worktree.

## Test plan
- [x] `yarn tsc --noEmit` passes
- [x] `yarn jest` passes (96 tests, including new coverage for `hide-page`, `cache`, `apply-state`, and the orchestration in `inject-css/index.ts`)
- [x] Manually verified in Chrome: first visit to a styled page hides briefly then shows the correct style with no flash of unstyled content; subsequent visits show no flash at all