### PR TITLE
Stop @import styles from blocking the rest of the stylesheet

### DIFF
--- a/scripts/launch-chrome.mjs
+++ b/scripts/launch-chrome.mjs
@@ -3,7 +3,7 @@
 // disabled that flag, and extensions loaded with it can't be reloaded.
 
 import { chromium } from 'playwright';
-import { existsSync, readFileSync, watch } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, watch } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -25,6 +25,10 @@ const readMarker = () => (existsSync(buildMarkerPath) ? readFileSync(buildMarker
 // Resolves once the marker file's content differs from `baseline`.
 const waitForMarkerChange = (baseline) =>
   new Promise((resolve) => {
+    // fs.watch throws ENOENT if the directory doesn't exist yet, which is
+    // the case on a fresh checkout before `yarn watch` has run once.
+    mkdirSync(extensionPath, { recursive: true });
+
     const checkNow = () => {
       if (readMarker() !== baseline) {
         watcher.close();

--- a/src/css/__tests__/import.test.ts
+++ b/src/css/__tests__/import.test.ts
@@ -1,7 +1,11 @@
 /* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/no-explicit-any */
 
 const dedent = require('dedent');
-import { getCssWithExpandedImports } from '../import';
+import {
+  fetchImportCss,
+  getCssWithExpandedImports,
+  pruneImportCache,
+} from '../import';
 
 const mockFontCss = dedent`
   /* latin-ext */
@@ -46,6 +50,10 @@ global.chrome = {
 };
 
 describe('import', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
   describe('getCssWithExpandedImports', () => {
     it('correctly parses @import url(<url>)', async () => {
       const css = dedent`
@@ -223,6 +231,105 @@ describe('import', () => {
         color: red;
       }
     `);
+    });
+  });
+
+  describe('fetchImportCss', () => {
+    const originalSendMessage = global.chrome.runtime.sendMessage;
+
+    afterEach(() => {
+      global.chrome.runtime.sendMessage = originalSendMessage;
+    });
+
+    it('fetches and caches the response when nothing is cached', async () => {
+      const sendMessage = jest.fn(
+        (_message: any, callback: (response: string) => void) => {
+          callback('.a{color:red}');
+        }
+      );
+      global.chrome.runtime.sendMessage = sendMessage as any;
+
+      const result = await fetchImportCss('https://example.com/a.css');
+
+      expect(result).toBe('.a{color:red}');
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+      expect(
+        localStorage.getItem('stylebot-import-cache:https://example.com/a.css')
+      ).toBe('.a{color:red}');
+    });
+
+    it('resolves from the cache without waiting on the fetch to complete', async () => {
+      localStorage.setItem(
+        'stylebot-import-cache:https://example.com/a.css',
+        '.cached{}'
+      );
+
+      let deliver: (response: string) => void = () => undefined;
+      const sendMessage = jest.fn(
+        (_message: any, callback: (response: string) => void) => {
+          deliver = callback;
+        }
+      );
+      global.chrome.runtime.sendMessage = sendMessage as any;
+
+      const result = await fetchImportCss('https://example.com/a.css');
+
+      expect(result).toBe('.cached{}');
+      // still refreshes the cache in the background
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+
+      deliver('.fresh{}');
+    });
+
+    it('does not cache an empty response', async () => {
+      const sendMessage = jest.fn(
+        (_message: any, callback: (response: string) => void) => {
+          callback('');
+        }
+      );
+      global.chrome.runtime.sendMessage = sendMessage as any;
+
+      await fetchImportCss('https://example.com/missing.css');
+
+      expect(
+        localStorage.getItem(
+          'stylebot-import-cache:https://example.com/missing.css'
+        )
+      ).toBeNull();
+    });
+  });
+
+  describe('pruneImportCache', () => {
+    it('removes cache entries for urls that are no longer live', () => {
+      localStorage.setItem(
+        'stylebot-import-cache:https://example.com/still-used.css',
+        '.a{}'
+      );
+      localStorage.setItem(
+        'stylebot-import-cache:https://example.com/removed.css',
+        '.b{}'
+      );
+
+      pruneImportCache(new Set(['https://example.com/still-used.css']));
+
+      expect(
+        localStorage.getItem(
+          'stylebot-import-cache:https://example.com/still-used.css'
+        )
+      ).toBe('.a{}');
+      expect(
+        localStorage.getItem(
+          'stylebot-import-cache:https://example.com/removed.css'
+        )
+      ).toBeNull();
+    });
+
+    it('leaves unrelated localStorage keys alone', () => {
+      localStorage.setItem('some-other-key', 'value');
+
+      pruneImportCache(new Set());
+
+      expect(localStorage.getItem('some-other-key')).toBe('value');
     });
   });
 });

--- a/src/css/__tests__/inject-style.test.ts
+++ b/src/css/__tests__/inject-style.test.ts
@@ -1,0 +1,95 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { injectCSSIntoDocument, removeCSSFromDocument } from '../inject-style';
+
+const stylesheetId = (id: string) => `stylebot-css-${id}`;
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0));
+
+describe('inject-style', () => {
+  afterEach(() => {
+    document
+      .querySelectorAll('style[id^="stylebot-css-"]')
+      .forEach(el => el.remove());
+    delete (global as any).chrome;
+  });
+
+  describe('injectCSSIntoDocument', () => {
+    it('creates a style element with the given css', async () => {
+      await injectCSSIntoDocument('a { color: red; }', 'example');
+
+      const style = document.getElementById(stylesheetId('example'));
+
+      expect(style?.tagName).toBe('STYLE');
+      expect(style?.textContent).toContain('color: red');
+    });
+
+    it('updates an existing style element in place, rather than duplicating it', async () => {
+      await injectCSSIntoDocument('a { color: red; }', 'example');
+      await injectCSSIntoDocument('a { color: blue; }', 'example');
+
+      const elements = document.querySelectorAll(
+        `#${stylesheetId('example')}`
+      );
+
+      expect(elements).toHaveLength(1);
+      expect(elements[0].textContent).toContain('color: blue');
+    });
+
+    it('resolves without a background round trip when there is no @import', async () => {
+      (global as any).chrome = { runtime: { sendMessage: jest.fn() } };
+
+      await injectCSSIntoDocument('a { color: red; }', 'example');
+
+      expect(
+        (global as any).chrome.runtime.sendMessage
+      ).not.toHaveBeenCalled();
+    });
+
+    it('applies the rest of the css immediately, without waiting on an @import fetch', async () => {
+      let deliverImport: (css: string) => void = () => undefined;
+
+      (global as any).chrome = {
+        runtime: {
+          sendMessage: jest.fn(
+            (_message: unknown, callback: (response: string) => void) => {
+              deliverImport = callback;
+            }
+          ),
+        },
+      };
+
+      const css = `
+        @import url(https://fonts.example.com/font.css);
+        a { color: red; }
+      `;
+
+      await injectCSSIntoDocument(css, 'example');
+
+      const style = document.getElementById(stylesheetId('example'));
+
+      expect(style?.textContent).toContain('color: red');
+      expect(style?.textContent).not.toContain('@import');
+
+      deliverImport('@font-face { font-family: "Test"; }');
+      await flush();
+
+      expect(style?.textContent).toContain('@font-face');
+      expect(style?.textContent).toContain('color: red');
+    });
+  });
+
+  describe('removeCSSFromDocument', () => {
+    it('clears the stylesheet content', async () => {
+      await injectCSSIntoDocument('a { color: red; }', 'example');
+      removeCSSFromDocument('example');
+
+      expect(
+        document.getElementById(stylesheetId('example'))?.textContent
+      ).toBe('');
+    });
+
+    it('does nothing if the stylesheet does not exist', () => {
+      expect(() => removeCSSFromDocument('missing')).not.toThrow();
+    });
+  });
+});

--- a/src/css/import.ts
+++ b/src/css/import.ts
@@ -26,16 +26,80 @@ export const extractImports = (
   return { css: root.toString(), importUrls };
 };
 
+const IMPORT_CACHE_PREFIX = 'stylebot-import-cache:';
+const importCacheKey = (url: string) => `${IMPORT_CACHE_PREFIX}${url}`;
+
+const readImportCache = (url: string): string | null => {
+  try {
+    return localStorage.getItem(importCacheKey(url));
+  } catch {
+    return null;
+  }
+};
+
+const writeImportCache = (url: string, css: string): void => {
+  try {
+    localStorage.setItem(importCacheKey(url), css);
+  } catch {
+    // localStorage may be unavailable (e.g. blocked by the page); the next
+    // load will simply fetch again instead of hitting the cache.
+  }
+};
+
+// Removes cached @import responses for urls no longer referenced by any
+// current style, so editing or removing an @import doesn't leak its cache
+// entry on this origin forever.
+export const pruneImportCache = (liveUrls: ReadonlySet<string>): void => {
+  try {
+    const staleKeys: Array<string> = [];
+
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+
+      if (
+        key &&
+        key.startsWith(IMPORT_CACHE_PREFIX) &&
+        !liveUrls.has(key.slice(IMPORT_CACHE_PREFIX.length))
+      ) {
+        staleKeys.push(key);
+      }
+    }
+
+    staleKeys.forEach(key => localStorage.removeItem(key));
+  } catch {
+    // localStorage may be unavailable; nothing to clean up then.
+  }
+};
+
 // Fetches one @import's CSS via the background service worker, to get
 // around CORS.
-export const fetchImportCss = (url: string): Promise<string> =>
+const fetchAndCacheImportCss = (url: string): Promise<string> =>
   new Promise(resolve => {
     const message: GetImportCss = { name: 'GetImportCss', url };
 
     chrome.runtime.sendMessage(message, (response: GetImportCssResponse) => {
+      if (response) {
+        writeImportCache(url, response);
+      }
+
       resolve(response);
     });
   });
+
+// Imported CSS (e.g. a Google Font) rarely changes and fetching it always
+// goes through the background service worker, which can be slow to wake
+// from cold. A cached response resolves immediately; it's still refreshed
+// in the background so a real change eventually reaches the next load.
+export const fetchImportCss = (url: string): Promise<string> => {
+  const cached = readImportCache(url);
+
+  if (cached === null) {
+    return fetchAndCacheImportCss(url);
+  }
+
+  fetchAndCacheImportCss(url);
+  return Promise.resolve(cached);
+};
 
 export const getCssWithExpandedImports = async (
   css: string

--- a/src/css/import.ts
+++ b/src/css/import.ts
@@ -2,49 +2,47 @@ import * as postcss from 'postcss';
 
 import { GetImportCss, GetImportCssResponse } from '@stylebot/types';
 
-// fetch and expand all imports for external CSS to get around CORS
-export const getCssWithExpandedImports = (css: string): Promise<string> => {
-  return new Promise(resolve => {
-    const root = postcss.parse(css);
-    const urls: Array<string> = [];
+// Strips @import rules out so the rest of the CSS can be applied without
+// waiting on a network fetch for them.
+export const extractImports = (
+  css: string
+): { css: string; importUrls: Array<string> } => {
+  const root = postcss.parse(css);
+  const importUrls: Array<string> = [];
 
-    root.walkAtRules('import', (atRule: postcss.AtRule) => {
-      const regex = /^(url\()?([^\)]*)(\))?$/;
-      const paramsWithoutQuotes = atRule.params
-        .replace(/"/g, '')
-        .replace(/\'/g, '');
-      const matches = paramsWithoutQuotes.match(regex);
+  root.walkAtRules('import', (atRule: postcss.AtRule) => {
+    const regex = /^(url\()?([^\)]*)(\))?$/;
+    const paramsWithoutQuotes = atRule.params
+      .replace(/"/g, '')
+      .replace(/\'/g, '');
+    const matches = paramsWithoutQuotes.match(regex);
 
-      if (matches) {
-        urls.push(matches[2]);
-        atRule.remove();
-      }
-    });
+    if (matches) {
+      importUrls.push(matches[2]);
+      atRule.remove();
+    }
+  });
 
-    const promises: Array<Promise<string>> = urls.map(url => {
-      return new Promise(urlResolve => {
-        const message: GetImportCss = {
-          name: 'GetImportCss',
-          url,
-        };
+  return { css: root.toString(), importUrls };
+};
 
-        chrome.runtime.sendMessage(
-          message,
-          (response: GetImportCssResponse) => {
-            urlResolve(response);
-          }
-        );
-      });
-    });
+// Fetches one @import's CSS via the background service worker, to get
+// around CORS.
+export const fetchImportCss = (url: string): Promise<string> =>
+  new Promise(resolve => {
+    const message: GetImportCss = { name: 'GetImportCss', url };
 
-    let output = root.toString();
-    Promise.all(promises).then((values: Array<string>) => {
-      const merged = values.join('\n\n');
-      if (merged) {
-        output = `${merged}\n\n${output}`;
-      }
-
-      resolve(output);
+    chrome.runtime.sendMessage(message, (response: GetImportCssResponse) => {
+      resolve(response);
     });
   });
+
+export const getCssWithExpandedImports = async (
+  css: string
+): Promise<string> => {
+  const { css: withoutImports, importUrls } = extractImports(css);
+  const values = await Promise.all(importUrls.map(fetchImportCss));
+  const merged = values.join('\n\n');
+
+  return merged ? `${merged}\n\n${withoutImports}` : withoutImports;
 };

--- a/src/css/index.ts
+++ b/src/css/index.ts
@@ -9,6 +9,8 @@ export {
   removeCSSFromDocument,
 } from './inject-style';
 
+export { extractImports, pruneImportCache } from './import';
+
 export {
   getSelector,
   getIdBasedSelector,

--- a/src/css/inject-style.ts
+++ b/src/css/inject-style.ts
@@ -1,22 +1,17 @@
 import * as postcss from 'postcss';
 import { appendImportantToDeclarations } from './declaration';
-import { getCssWithExpandedImports } from './import';
+import { extractImports, fetchImportCss } from './import';
 
 const getStylesheetId = (id: string) => {
   return `stylebot-css-${id}`;
 };
 
-export const injectCSSIntoDocument = async (
-  css: string,
-  id: string
-): Promise<void> => {
-  const cssWithExpandedImports = await getCssWithExpandedImports(css);
-
+const setStylesheetContent = (id: string, css: string): void => {
   const stylesheetId = getStylesheetId(id);
   const el = document.getElementById(stylesheetId);
 
   if (el) {
-    el.innerHTML = cssWithExpandedImports;
+    el.innerHTML = css;
     return;
   }
 
@@ -24,9 +19,33 @@ export const injectCSSIntoDocument = async (
 
   style.type = 'text/css';
   style.setAttribute('id', stylesheetId);
-  style.appendChild(document.createTextNode(cssWithExpandedImports));
+  style.appendChild(document.createTextNode(css));
 
   document.documentElement.appendChild(style);
+};
+
+// Applies the non-`@import` CSS immediately and patches in any `@import`
+// content once it's fetched, so a slow import fetch (e.g. a cold background
+// service worker) never blocks the rest of the stylesheet from applying.
+export const injectCSSIntoDocument = async (
+  css: string,
+  id: string
+): Promise<void> => {
+  const { css: withoutImports, importUrls } = extractImports(css);
+
+  setStylesheetContent(id, withoutImports);
+
+  if (importUrls.length === 0) {
+    return;
+  }
+
+  Promise.all(importUrls.map(fetchImportCss)).then(values => {
+    const merged = values.join('\n\n');
+
+    if (merged) {
+      setStylesheetContent(id, `${merged}\n\n${withoutImports}`);
+    }
+  });
 };
 
 export const injectRootIntoDocument = (

--- a/src/inject-css/__tests__/index.test.ts
+++ b/src/inject-css/__tests__/index.test.ts
@@ -98,13 +98,13 @@ describe('inject-css run()', () => {
 
   it('patches to the fresh state when it differs from a stale cache', async () => {
     const cached = {
-      styles: [{ url: 'a', css: '.a{old}', enabled: true }],
+      styles: [{ url: 'a', css: '.a{color:old}', enabled: true }],
       readability: false,
     };
 
     (cacheModule.readCache as jest.Mock).mockReturnValue(cached);
     (stylesModule.getStylesForPage as jest.Mock).mockReturnValue({
-      styles: [{ url: 'a', css: '.a{new}', enabled: true }],
+      styles: [{ url: 'a', css: '.a{color:new}', enabled: true }],
       defaultStyle: undefined,
     });
 
@@ -112,7 +112,7 @@ describe('inject-css run()', () => {
     await flushPromises();
 
     const freshState = {
-      styles: [{ url: 'a', css: '.a{new}', enabled: true }],
+      styles: [{ url: 'a', css: '.a{color:new}', enabled: true }],
       readability: false,
     };
 

--- a/src/inject-css/index.ts
+++ b/src/inject-css/index.ts
@@ -3,6 +3,7 @@
  * localStorage cache (cache.ts) immediately if there is one, otherwise hides
  * the page (hide-page.ts) until chrome.storage.local.get resolves.
  */
+import { extractImports, pruneImportCache } from '@stylebot/css';
 import { getStylesForPage } from '@stylebot/styles';
 import { StyleMap } from '@stylebot/types';
 
@@ -40,6 +41,14 @@ const run = () => {
 
     const finish = () => {
       writeCache(freshState);
+
+      const liveImportUrls = new Set(
+        freshState.styles.flatMap(
+          style => extractImports(style.css).importUrls
+        )
+      );
+      pruneImportCache(liveImportUrls);
+
       clearTimeout(revealTimeout);
       revealPage();
     };


### PR DESCRIPTION
Follow-up to #834.

## Summary
- `injectCSSIntoDocument` used to await the full `@import` fetch (a round trip through the background service worker, to get around CORS) before applying any CSS at all. A cold service worker made that slow enough to defeat #834's hide-until-ready fix, reintroducing a flash for any style using `@import`. The non-`@import` CSS is now applied immediately; `@import` content is fetched separately and patched into the same stylesheet once it arrives.
- Fetched `@import` CSS (e.g. a Google Font) is now cached in `localStorage` by url, since it rarely changes but was being re-fetched through the service worker on every single load. Cached content applies immediately on the next load, with a background refetch to keep it current.
- Cache entries for urls no longer referenced by any style are pruned after each load, so removing an `@import` doesn't leak its entry forever.
- Fixed `yarn dev:chrome` failing on a fresh checkout (`fs.watch` needs the `dist/` directory to already exist).

## Test plan
- [x] `yarn tsc --noEmit` passes
- [x] `yarn jest` passes (107 tests, including coverage for the non-blocking injection, the import cache, and pruning)