### PR TITLE
fix: wrap long URLs in the styles overview

### DIFF
--- a/src/options/components/styles/Style.vue
+++ b/src/options/components/styles/Style.vue
@@ -14,7 +14,7 @@
 
     <b-col cols="7">
       <b-form-checkbox v-model="enabled" @change="$emit('toggle')">
-        {{ url }}
+        <span class="style-url">{{ url }}</span>
       </b-form-checkbox>
 
       <span class="style-timestamp">updated {{ formattedTimestamp }}</span>
@@ -106,6 +106,10 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .style {
   border-bottom: 1px solid #ddd;
+}
+
+.style-url {
+  overflow-wrap: anywhere;
 }
 
 .style-timestamp {


### PR DESCRIPTION
Fixes #822

## Summary
- The URL in each row of the styles overview (`src/options/components/styles/Style.vue`) had no wrap rule, so a long, unbroken URL overflowed past its column and covered the Edit/Delete buttons, making them unclickable.
- Wraps the URL text in a `<span class="style-url">` with `overflow-wrap: anywhere`, so long URLs break onto new lines instead of overflowing.

## Test plan
- [x] `npx eslint` on the changed file — clean
- [x] `npx tsc --noEmit` — no new errors
- [x] Manually verified in a loaded build: added a style with a very long URL and confirmed it now wraps across multiple lines with the Edit/Delete buttons fully visible and clickable