### PR TITLE
fix: upgrade monaco-editor to fix false syntax errors on modern CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "lint-staged": "^10.5.4",
     "lodash": "^4.17.19",
     "mini-css-extract-plugin": "^0.9.0",
-    "monaco-editor": "^0.20.0",
+    "monaco-editor": "^0.56.0",
     "patch-package": "^6.2.2",
     "playwright": "^1.62.1",
     "postcss": "^7.0.32",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,6 +58,10 @@ const config = {
     minimizer: [
       new TerserPlugin({
         parallel: true,
+        // The monaco-editor package under min/vs is copied in pre-minified
+        // (see CopyPlugin below) and uses syntax newer than this project's
+        // pinned Terser can parse, so re-minifying it just breaks the build.
+        exclude: /monaco-editor\/iframe\/node_modules\/monaco-editor/,
         terserOptions: {
           ecma: 6,
           output: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1333,6 +1333,11 @@
   resolved "https://registry.yarnpkg.com/@types/tinycolor2/-/tinycolor2-1.4.2.tgz#721ca5c5d1a2988b4a886e35c2ffc5735b6afbdf"
   integrity sha512-PeHg/AtdW6aaIO2a+98Xj7rWY4KC1E6yOy7AFknJQ7VXUGNrMlyxDFxJo7HqLtjQms/ZhhQX52mLVW/EX3JGOw==
 
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
@@ -3840,6 +3845,13 @@ domhandler@^2.3.0:
   integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
   dependencies:
     domelementtype "1"
+
+dompurify@3.4.8:
+  version "3.4.8"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.8.tgz#6c54f8c207160e7f83fcb7f4fd05a82ac36b1cdc"
+  integrity sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 domutils@1.5.1:
   version "1.5.1"
@@ -6941,6 +6953,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+marked@14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-14.0.0.tgz#79a1477358a59e0660276f8fec76de2c33f35d83"
+  integrity sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==
+
 marky@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/marky/-/marky-1.2.1.tgz#a3fcf82ffd357756b8b8affec9fdbf3a30dc1b02"
@@ -7173,10 +7190,13 @@ moment@^2.19.3:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
-monaco-editor@^0.20.0:
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.20.0.tgz#5d5009343a550124426cb4d965a4d27a348b4dea"
-  integrity sha512-hkvf4EtPJRMQlPC3UbMoRs0vTAFAYdzFQ+gpMb8A+9znae1c43q8Mab9iVsgTcg/4PNiLGGn3SlDIa8uvK1FIQ==
+monaco-editor@^0.56.0:
+  version "0.56.0"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.56.0.tgz#e85ac00b7ab7092ca1d077894504919af5073cf0"
+  integrity sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==
+  dependencies:
+    dompurify "3.4.8"
+    marked "14.0.0"
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Fixes #817
Fixes #763

## Summary
- `monaco-editor` was pinned at `0.20.0` (2020). Its bundled CSS language service predates selectors like `:has()`, so valid CSS was flagged with a false syntax error (red squiggly) in the editor.
- Upgrades `monaco-editor` to `0.56.0`.
- The upgrade alone broke the production build: this project's pinned Terser can't parse the modern JS syntax used in the newer monaco worker/language bundles. Those files are copied in pre-minified via `CopyPlugin` (`webpack.config.js`) and don't need re-minifying anyway, so `TerserPlugin` now excludes them.

## Test plan
- [x] `yarn build` succeeds
- [x] `npx eslint` — clean
- [x] `npx tsc --noEmit` — no new errors
- [x] `npx jest` — 107/107 passing
- [x] Manually verified via `yarn dev:chrome`: pasted the `:has()` repro from #817 into the Stylebot editor and confirmed no false syntax error is shown