### PR TITLE
fix: editor host stays visible against page :empty CSS resets

### DIFF
--- a/src/editor/utils/init-editor.ts
+++ b/src/editor/utils/init-editor.ts
@@ -67,6 +67,13 @@ const initEditor = (store: Store<State>): void => {
 
   const stylebotAppHost = document.createElement('div');
   stylebotAppHost.id = 'stylebot';
+
+  // stylebotAppHost only ever gets a shadow root, so :empty matches it
+  // forever — a page rule as common as `:empty { display: none }` would
+  // otherwise hide the entire editor. An inline !important beats any
+  // non-inline-!important page rule regardless of selector.
+  stylebotAppHost.style.setProperty('display', 'block', 'important');
+
   document.body.appendChild(stylebotAppHost);
 
   const shadowRoot = stylebotAppHost.attachShadow({ mode: 'open' });


### PR DESCRIPTION
Fixes #778

## Summary
- `stylebotAppHost` (`src/editor/utils/init-editor.ts`) is a plain `<div id="stylebot">` appended to `document.body` with no protective styling of its own — it only ever gets a shadow root, never any light-DOM children, so `:empty` matches it forever (`:empty` only counts light-DOM children, not shadow content).
- Any site whose stylesheet contains a rule as common as `:empty { display: none }` (a standard CSS reset pattern) permanently hides the entire Stylebot editor, exactly as reported in #778.
- Sets `display: block !important` directly as an inline style on the host element. An inline `!important` declaration beats any non-inline-`!important` author stylesheet rule regardless of selector, so this can't be clobbered by generic page CSS the way a stylesheet-based fix could.

## Test plan
- [x] `npx eslint` — clean
- [x] `npx tsc --noEmit` — no new errors
- [x] `npx jest` — 107/107 passing
- [x] Manually verified: loaded the built extension against a local page containing `:empty { display: none }` in its stylesheet and confirmed the editor now opens and renders correctly (previously the host element, and thus the whole editor, would be hidden)