### PR TITLE
fix: editor panel no longer gets covered by the host page's own content

### DIFF
--- a/src/editor/utils/init-editor.ts
+++ b/src/editor/utils/init-editor.ts
@@ -68,11 +68,16 @@ const initEditor = (store: Store<State>): void => {
   const stylebotAppHost = document.createElement('div');
   stylebotAppHost.id = 'stylebot';
 
-  // stylebotAppHost only ever gets a shadow root, so :empty matches it
-  // forever — a page rule as common as `:empty { display: none }` would
-  // otherwise hide the entire editor. An inline !important beats any
-  // non-inline-!important page rule regardless of selector.
-  stylebotAppHost.style.setProperty('display', 'block', 'important');
+  // !important beats page rules that would hide this; fixed + max z-index
+  // beats page content stacked above it. Sized 0x0, the panel is its own fixed element.
+  const hostStyle = stylebotAppHost.style;
+  hostStyle.setProperty('display', 'block', 'important');
+  hostStyle.setProperty('position', 'fixed', 'important');
+  hostStyle.setProperty('top', '0', 'important');
+  hostStyle.setProperty('left', '0', 'important');
+  hostStyle.setProperty('width', '0', 'important');
+  hostStyle.setProperty('height', '0', 'important');
+  hostStyle.setProperty('z-index', '2147483647', 'important');
 
   document.body.appendChild(stylebotAppHost);
 


### PR DESCRIPTION
Fixes #790

## Summary
The editor panel already sets a huge `z-index`, but that only matters within a stacking context. The shadow host div was `position: static` / `z-index: auto`, so it established none — any page content appended to `<body>` after it (like bsky.app's own modal) simply painted over the panel regardless. Fix: make the host `position: fixed` with `z-index: 2147483647`, sized 0×0 so it can't intercept clicks or affect layout.

Likely also explains #740 (comments there describe the same symptom: "some sites have elements that simply fall on top of the menu"), though only verified against bsky.app here.

## Test plan
- [x] `npx eslint` / `npx tsc --noEmit` — clean
- [x] `npx jest` — 107/107 passing
- [x] Verified live against bsky.app: panel was hidden behind its welcome modal before, renders on top and is usable after