### PR TITLE
fix: wait for editor stylesheet before mounting to avoid unstyled flash

### DIFF
--- a/src/editor/utils/init-editor.ts
+++ b/src/editor/utils/init-editor.ts
@@ -47,10 +47,10 @@ Vue.mixin({
   },
 });
 
-const injectCss = (shadowRoot: ShadowRoot): void => {
+const injectCss = (shadowRoot: ShadowRoot): Promise<void> => {
   const url = chrome.runtime.getURL('editor/index.css');
 
-  fetch(url, { method: 'GET' })
+  return fetch(url, { method: 'GET' })
     .then(response => response.text())
     .then(css => {
       const styleEl = document.createElement('style');
@@ -87,12 +87,15 @@ const initEditor = (store: Store<State>): void => {
   stylebotApp.id = 'stylebot-app';
   shadowRoot.appendChild(stylebotApp);
 
-  injectCss(shadowRoot);
-
-  new Vue({
-    store,
-    el: stylebotApp,
-    render: h => h(TheStylebotApp),
+  // Wait for the stylesheet to land before mounting — otherwise Vue's
+  // synchronous mount renders the unstyled markup first, causing a
+  // visible flash whenever the CSS fetch is slower than the mount.
+  injectCss(shadowRoot).then(() => {
+    new Vue({
+      store,
+      el: stylebotApp,
+      render: h => h(TheStylebotApp),
+    });
   });
 };
 


### PR DESCRIPTION
## Summary
- `initEditor()` (`src/editor/utils/init-editor.ts`) fetches the editor's own CSS asynchronously (`injectCss`) and only appends the `<style>` tag to the shadow root once that fetch resolves, but mounts the Vue app synchronously in the same tick (Vue 2 mounts immediately when `el` is passed in the constructor).
- That leaves a window where the unstyled markup is rendered before the CSS lands. Opening via the keyboard shortcut skips the popup-click round trip that otherwise usually gives the fetch enough time to win the race, so the flash is most visible there — matches the reported "sometimes opens unstyled" behavior.
- Fix: `injectCss` now returns its promise, and the Vue app isn't constructed until it resolves, so the shadow root always has its stylesheet in place before anything renders.

## Test plan
- [x] `npx eslint` / `npx tsc --noEmit` — clean
- [x] `npx jest` — 125/125 passing
- [x] Manually verified via `yarn dev:chrome`: repeatedly opened the editor with the keyboard shortcut right after fresh page loads — no more unstyled flash