### PR TITLE
fix: keep localStorage cache in sync with live editor CSS changes

### DIFF
--- a/src/editor/store/__tests__/actions.test.ts
+++ b/src/editor/store/__tests__/actions.test.ts
@@ -4,6 +4,7 @@ import actions from '../actions';
 import mockState from '../__mocks__/state';
 import * as stylebotCss from '@stylebot/css';
 import * as chromeUtils from '../../utils/chrome';
+import { readCache, writeCache } from '../../../inject-css/cache';
 
 jest.mock('postcss');
 jest.mock('@stylebot/css');
@@ -68,6 +69,64 @@ describe('actions', () => {
         css,
         mockState.readability
       );
+    });
+
+    afterEach(() => {
+      localStorage.clear();
+    });
+
+    it('does nothing to the cache when nothing is cached yet', () => {
+      const css = 'a { color: red; }';
+      jest.spyOn(stylebotCss, 'removeEmptyRules').mockReturnValue(css);
+
+      actions.applyCss({ commit: mockCommit, state: mockState }, { css });
+
+      expect(readCache()).toBeNull();
+    });
+
+    it('updates the matching cached style in place', () => {
+      const css = 'a { color: red; }';
+      jest.spyOn(stylebotCss, 'removeEmptyRules').mockReturnValue(css);
+
+      writeCache({
+        styles: [
+          { url: mockState.url, css: 'a { color: blue; }', enabled: true },
+          { url: 'other.example.com', css: 'b { color: green; }', enabled: true },
+        ],
+        readability: false,
+      });
+
+      actions.applyCss({ commit: mockCommit, state: mockState }, { css });
+
+      expect(readCache()).toEqual({
+        styles: [
+          { url: mockState.url, css, enabled: mockState.enabled },
+          { url: 'other.example.com', css: 'b { color: green; }', enabled: true },
+        ],
+        readability: false,
+      });
+    });
+
+    it('appends a cached style if none exists yet for this url', () => {
+      const css = 'a { color: red; }';
+      jest.spyOn(stylebotCss, 'removeEmptyRules').mockReturnValue(css);
+
+      writeCache({
+        styles: [
+          { url: 'other.example.com', css: 'b { color: green; }', enabled: true },
+        ],
+        readability: false,
+      });
+
+      actions.applyCss({ commit: mockCommit, state: mockState }, { css });
+
+      expect(readCache()).toEqual({
+        styles: [
+          { url: 'other.example.com', css: 'b { color: green; }', enabled: true },
+          { url: mockState.url, css, enabled: mockState.enabled },
+        ],
+        readability: false,
+      });
     });
   });
 

--- a/src/editor/store/actions.ts
+++ b/src/editor/store/actions.ts
@@ -43,6 +43,7 @@ import {
 
 import { initListeners } from '../listeners';
 import { initEditor } from '../utils/init-editor';
+import { readCache, writeCache } from '../../inject-css/cache';
 
 export default {
   async initialize(
@@ -161,6 +162,24 @@ export default {
       // when saving, cleanup any empty rules
       const cleanCss = removeEmptyRules(css);
       setStyle(state.url, cleanCss, state.readability);
+
+      // Keep the localStorage cache (read synchronously on the next page
+      // load, before chrome.storage.local resolves) in sync with edits, so
+      // reloading right after a change doesn't flash the pre-edit CSS.
+      const cached = readCache();
+      if (cached) {
+        const entry = { url: state.url, css: cleanCss, enabled: state.enabled };
+        const exists = cached.styles.some(style => style.url === state.url);
+
+        writeCache({
+          ...cached,
+          styles: exists
+            ? cached.styles.map(style =>
+                style.url === state.url ? entry : style
+              )
+            : [...cached.styles, entry],
+        });
+      }
     } catch (e) {
       //
     }


### PR DESCRIPTION
## Summary
- `applyCss()` (`src/editor/store/actions.ts`) persists edits to `chrome.storage.local` via `setStyle()`, but never touched the `localStorage` cache (`src/inject-css/cache.ts`) that the content script reads synchronously on the next page load, before `chrome.storage.local` resolves.
- Result: reloading a tab right after editing CSS would briefly re-apply the stale pre-edit cache, then patch to the new version once the async storage read caught up — most noticeable when removing a large chunk of CSS, since the delta between stale and fresh is bigger.
- Fix: `applyCss` now also updates the cached entry for the current url in place (or appends one if missing), whenever a cache already exists for this origin.

## Test plan
- [x] `npx eslint` / `npx tsc --noEmit` — clean
- [x] `npx jest` — 128/128 passing, including new coverage for the cache-sync behavior (no-op when nothing cached yet, update in place, append when missing)
- [x] Manually verified via `yarn dev:chrome`: added a large chunk of CSS, removed most of it, reloaded the tab — no more flash of the pre-edit CSS