### PR TITLE
fix: enable CSS editor hover and quiet non-actionable lint warnings

### DIFF
--- a/src/monaco-editor/iframe/MonacoEditorIframe.ts
+++ b/src/monaco-editor/iframe/MonacoEditorIframe.ts
@@ -17,6 +17,7 @@ class MonacEditorIframe {
     this.loadEditor(() => {
       this.attachWindowListeners();
       this.defineThemes();
+      this.configureDiagnostics();
       this.initEditor();
       this.postMessage({ type: 'stylebotMonacoIframeLoaded' });
     });
@@ -36,6 +37,14 @@ class MonacEditorIframe {
 
   defineThemes(): void {
     window.monaco.editor.defineTheme('custom-light', CustomLight);
+  }
+
+  configureDiagnostics(): void {
+    // Both fire on normal Stylebot usage (empty rules on element pick,
+    // single-browser vendor-prefixed hacks) rather than real mistakes.
+    window.monaco.languages.css.cssDefaults.setDiagnosticsOptions({
+      lint: { emptyRules: 'ignore', vendorPrefix: 'ignore' },
+    });
   }
 
   initEditor(): void {
@@ -80,7 +89,7 @@ class MonacEditorIframe {
         enabled: false,
       },
       hover: {
-        enabled: false,
+        enabled: true,
       },
       codeLens: false,
     };


### PR DESCRIPTION
Fixes #794

## Summary
- `hover: { enabled: false }` in `MonacoEditorIframe.ts` meant there was no way to see why something was underlined without guessing — matches the "No definition found for '-webkit-box-shadow'" tooltip only reachable via right-click in #794, and the more recent complaint that hovering a warning showed nothing at all. Hover is now enabled.
- Also suppress two lint rules that fire on entirely normal Stylebot usage rather than real mistakes:
  - `emptyRules` — every element pick inserts an empty rule stub (`addEmptyRule`), so this warned on essentially every use of the editor before you'd typed anything.
  - `vendorPrefix` ("also define the standard property for compatibility") — a production cross-browser-authoring best practice that doesn't apply here; Stylebot targets the one browser you're already using, not code shipped to the public web.
- Other lint rules (unknown properties, invalid values, etc.) are untouched since those catch real mistakes.

## Test plan
- [x] `npx eslint` / `npx tsc --noEmit` — clean
- [x] `npx jest` — 128/128 passing
- [x] Manually verified via `yarn dev:chrome`