### PR TITLE
fix: stop readability blank page, flashing, and misapplicable toggle

### DIFF
--- a/src/css/index.ts
+++ b/src/css/index.ts
@@ -9,7 +9,11 @@ export {
   removeCSSFromDocument,
 } from './inject-style';
 
-export { extractImports, pruneImportCache } from './import';
+export {
+  extractImports,
+  pruneImportCache,
+  getCssWithExpandedImports,
+} from './import';
 
 export {
   getSelector,

--- a/src/editor/store/__tests__/actions.test.ts
+++ b/src/editor/store/__tests__/actions.test.ts
@@ -3,11 +3,13 @@ import actions from '../actions';
 
 import mockState from '../__mocks__/state';
 import * as stylebotCss from '@stylebot/css';
+import * as stylebotReadability from '@stylebot/readability';
 import * as chromeUtils from '../../utils/chrome';
 import { readCache, writeCache } from '../../../inject-css/cache';
 
 jest.mock('postcss');
 jest.mock('@stylebot/css');
+jest.mock('@stylebot/readability');
 jest.mock('../../utils/chrome');
 
 const mockRoot = ({
@@ -127,6 +129,34 @@ describe('actions', () => {
         ],
         readability: false,
       });
+    });
+  });
+
+  describe('applyReadability', () => {
+    afterEach(() => {
+      localStorage.clear();
+    });
+
+    it('does nothing to the cache when nothing is cached yet', () => {
+      actions.applyReadability({ commit: mockCommit, state: mockState }, true);
+
+      expect(readCache()).toBeNull();
+    });
+
+    it('updates the cached readability flag in place', () => {
+      writeCache({
+        styles: [{ url: mockState.url, css: 'a { color: blue; }', enabled: true }],
+        readability: false,
+      });
+
+      actions.applyReadability({ commit: mockCommit, state: mockState }, true);
+
+      expect(readCache()).toEqual({
+        styles: [{ url: mockState.url, css: 'a { color: blue; }', enabled: true }],
+        readability: true,
+      });
+      expect(stylebotReadability.apply).toBeCalledWith(true);
+      expect(chromeUtils.setReadability).toBeCalledWith(mockState.url, true);
     });
   });
 

--- a/src/editor/store/actions.ts
+++ b/src/editor/store/actions.ts
@@ -237,6 +237,13 @@ export default {
 
     commit('setReadability', value);
     setReadability(state.url, value);
+
+    // Keep the localStorage cache in sync so a refresh right after
+    // toggling doesn't apply the stale readability state.
+    const cached = readCache();
+    if (cached) {
+      writeCache({ ...cached, readability: value });
+    }
   },
 
   setReadabilitySettings(

--- a/src/inject-css/__tests__/index.test.ts
+++ b/src/inject-css/__tests__/index.test.ts
@@ -3,6 +3,7 @@ jest.mock('../apply-state');
 jest.mock('../cache');
 jest.mock('../hide-page');
 jest.mock('@stylebot/styles');
+jest.mock('@stylebot/readability');
 
 const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0));
 
@@ -24,6 +25,7 @@ describe('inject-css run()', () => {
 
     (global as any).chrome = {
       storage: { local: { get: jest.fn() } },
+      runtime: { onMessage: { addListener: jest.fn() } },
     };
   });
 

--- a/src/inject-css/index.ts
+++ b/src/inject-css/index.ts
@@ -4,12 +4,25 @@
  * the page (hide-page.ts) until chrome.storage.local.get resolves.
  */
 import { extractImports, pruneImportCache } from '@stylebot/css';
+import { isReaderable } from '@stylebot/readability';
 import { getStylesForPage } from '@stylebot/styles';
-import { StyleMap } from '@stylebot/types';
+import { StyleMap, TabMessage } from '@stylebot/types';
 
 import { applyState } from './apply-state';
 import { CachedState, readCache, writeCache } from './cache';
 import { hidePage, revealPage } from './hide-page';
+
+// Registered synchronously here (unlike the editor script's listener,
+// gated behind async init) so the popup always gets a response.
+if (window === window.top) {
+  chrome.runtime.onMessage.addListener(
+    (message: TabMessage, _sender, sendResponse: (response: boolean) => void) => {
+      if (message.name === 'GetIsPageReaderable') {
+        sendResponse(isReaderable());
+      }
+    }
+  );
+}
 
 // Fallback if the storage read (or an @import fetch) stalls — real
 // completion almost always wins the race and reveals sooner.

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -9,7 +9,10 @@
         :initial-enabled="style.enabled"
       />
 
-      <readability :initial-readability="readability" />
+      <readability
+        :initial-readability="readability"
+        :disabled="!pageReaderable"
+      />
 
       <toggle-stylebot :is-open="isOpen" :tab="tab" />
 
@@ -32,7 +35,12 @@ import SyncStylebot from './components/SyncStylebot.vue';
 import ToggleStylebot from './components/ToggleStylebot.vue';
 import ReleaseNotification from './components/notifications/ReleaseNotification.vue';
 
-import { getStyles, getCurrentTab, getIsStylebotOpen } from './utils';
+import {
+  getStyles,
+  getCurrentTab,
+  getIsStylebotOpen,
+  getIsPageReaderable,
+} from './utils';
 
 // Bypasses @stylebot/sync, whose barrel also drags in runGoogleDriveSync's postcss dependency chain.
 import { getGoogleDriveSyncEnabled } from '../sync/google-drive/sync-metadata';
@@ -53,6 +61,7 @@ export default Vue.extend({
   data(): {
     isOpen: boolean;
     readability: boolean;
+    pageReaderable: boolean;
     tab?: chrome.tabs.Tab;
     styles: Array<{ url: string; css: string; enabled: boolean }>;
     googleDriveSyncEnabled: boolean;
@@ -63,6 +72,7 @@ export default Vue.extend({
       isOpen: false,
       tab: undefined,
       readability: false,
+      pageReaderable: true,
       googleDriveSyncEnabled: false,
       googleDriveSyncMetadata: undefined,
     };
@@ -74,6 +84,10 @@ export default Vue.extend({
 
       getIsStylebotOpen(this.tab, isOpen => {
         this.isOpen = isOpen;
+      });
+
+      getIsPageReaderable(this.tab, isReaderable => {
+        this.pageReaderable = isReaderable;
       });
 
       getStyles(this.tab, ({ styles, defaultStyle }) => {
@@ -137,5 +151,9 @@ span {
 
 .full-row-toggle {
   cursor: pointer;
+
+  &.disabled {
+    cursor: default;
+  }
 }
 </style>

--- a/src/popup/components/Readability.vue
+++ b/src/popup/components/Readability.vue
@@ -1,9 +1,14 @@
 <template>
-  <b-list-group-item class="full-row-toggle" @click="onRowClick">
+  <b-list-group-item
+    class="full-row-toggle"
+    :class="{ disabled }"
+    @click="onRowClick"
+  >
     <b-form-checkbox
       ref="checkbox"
       v-model="readability"
       switch
+      :disabled="disabled"
       @change="onChange"
     >
       {{ t('readability') }}
@@ -19,6 +24,7 @@ export default Vue.extend({
   name: 'Readability',
   props: {
     initialReadability: Boolean,
+    disabled: Boolean,
   },
 
   data(): {
@@ -37,6 +43,10 @@ export default Vue.extend({
 
   methods: {
     onRowClick(event: MouseEvent): void {
+      if (this.disabled) {
+        return;
+      }
+
       const target = event.target as HTMLElement;
 
       // Already handled natively by the label/input itself.

--- a/src/popup/utils.ts
+++ b/src/popup/utils.ts
@@ -2,6 +2,7 @@ import {
   ToggleStylebot,
   GetStylesForPage,
   GetIsStylebotOpen,
+  GetIsPageReaderable,
   GetStylesForPageResponse,
 } from '@stylebot/types';
 
@@ -44,6 +45,23 @@ export const getIsStylebotOpen = (
 
     chrome.tabs.sendMessage(tab.id, message, (response: boolean) =>
       callback(response)
+    );
+  }
+};
+
+export const getIsPageReaderable = (
+  tab: chrome.tabs.Tab,
+  callback: (isReaderable: boolean) => void
+): void => {
+  if (tab.id) {
+    const message: GetIsPageReaderable = {
+      name: 'GetIsPageReaderable',
+    };
+
+    // No response (e.g. no content script on this page, chrome:// urls)
+    // means readability can't apply here either.
+    chrome.tabs.sendMessage(tab.id, message, (response: boolean) =>
+      callback(!!response)
     );
   }
 };

--- a/src/readability/components/TheReader.vue
+++ b/src/readability/components/TheReader.vue
@@ -22,9 +22,13 @@
 import Vue from 'vue';
 
 import { defaultReadabilitySettings } from '@stylebot/settings';
-import { addGoogleWebFont, injectCSSIntoDocument } from '@stylebot/css';
+import {
+  addGoogleWebFont,
+  getCssWithExpandedImports,
+  injectCSSIntoDocument,
+} from '@stylebot/css';
 
-import { hideLoader } from '../loader';
+import { hideLoader, cacheTheme } from '../loader';
 
 import {
   GetReadabilitySettings,
@@ -70,16 +74,27 @@ export default Vue.extend({
   },
 
   async mounted(): Promise<void> {
-    const settings = await this.getReadabilitySettings();
-    await this.injectFont(settings.font);
+    try {
+      const settings = await this.getReadabilitySettings();
 
-    this.font = settings.font;
-    this.size = settings.size;
-    this.theme = settings.theme;
-    this.width = settings.width;
-    this.lineHeight = settings.lineHeight;
+      this.font = settings.font;
+      this.size = settings.size;
+      this.theme = settings.theme;
+      this.width = settings.width;
+      this.lineHeight = settings.lineHeight;
 
-    hideLoader();
+      cacheTheme(settings.theme);
+
+      // Bounded so a slow/broken font fetch can't stall the reveal for long.
+      await Promise.race([
+        this.injectFont(settings.font),
+        new Promise(resolve => setTimeout(resolve, 1500)),
+      ]);
+    } finally {
+      // Always reveal the reader — the original page is already gone,
+      // so a stalled/failed fetch here would otherwise blank the page.
+      hideLoader();
+    }
 
     chrome.runtime.onMessage.addListener((message: UpdateReader) => {
       if (message.name === 'UpdateReader') {
@@ -89,15 +104,28 @@ export default Vue.extend({
         this.width = message.value.width;
         this.lineHeight = message.value.lineHeight;
 
+        cacheTheme(message.value.theme);
         this.injectFont(this.font);
       }
     });
   },
 
   methods: {
-    async injectFont(font: string) {
+    async injectFont(font: string): Promise<void> {
       const css = await addGoogleWebFont(font, '');
-      injectCSSIntoDocument(css, 'reader-font');
+      const expandedCss = await getCssWithExpandedImports(css);
+
+      await injectCSSIntoDocument(expandedCss, 'reader-font');
+
+      // The reader is still hidden, so the browser won't fetch this font on
+      // its own — request it explicitly instead of using `fonts.ready`.
+      if (document.fonts) {
+        try {
+          await document.fonts.load(`16px "${font}"`);
+        } catch {
+          // font failed to load — reveal with whatever fallback is active
+        }
+      }
     },
 
     async getReadabilitySettings(): Promise<GetReadabilitySettingsResponse> {
@@ -105,7 +133,7 @@ export default Vue.extend({
         name: 'GetReadabilitySettings',
       };
 
-      return new Promise(resolve => {
+      const response = new Promise<GetReadabilitySettingsResponse>(resolve => {
         chrome.runtime.sendMessage(
           message,
           (response: GetReadabilitySettingsResponse) => {
@@ -113,6 +141,13 @@ export default Vue.extend({
           }
         );
       });
+
+      // Falls back to defaults if the service worker never responds.
+      const timeout = new Promise<GetReadabilitySettingsResponse>(resolve => {
+        setTimeout(() => resolve(defaultReadabilitySettings), 1000);
+      });
+
+      return Promise.race([response, timeout]);
     },
   },
 });

--- a/src/readability/index.ts
+++ b/src/readability/index.ts
@@ -1,5 +1,5 @@
 import { initReader } from './reader';
-import { shouldRunOnUrl } from './utils';
+import { shouldRunOnUrl, isReaderable } from './utils';
 import { showLoader, hideLoader } from './loader';
 import { cacheUrl, didUrlChange, revertToCachedDocument } from './cache';
 
@@ -46,3 +46,5 @@ export const remove = (): void => {
   revertToCachedDocument();
   document.getElementById('stylebot-reader')?.remove();
 };
+
+export { isReaderable };

--- a/src/readability/loader.ts
+++ b/src/readability/loader.ts
@@ -1,3 +1,23 @@
+import { ReadabilityTheme } from '@stylebot/types';
+
+// Read synchronously so the loading screen can match the reader's theme
+// immediately, instead of flashing white until settings are fetched.
+const THEME_CACHE_KEY = 'stylebot-reader-theme';
+
+const THEME_BACKGROUNDS: Record<ReadabilityTheme, string> = {
+  light: '#fff',
+  sepia: '#f4ecd8',
+  dark: '#222',
+};
+
+export const cacheTheme = (theme: ReadabilityTheme): void => {
+  try {
+    localStorage.setItem(THEME_CACHE_KEY, theme);
+  } catch {
+    // localStorage may be unavailable; the loader just falls back to light.
+  }
+};
+
 /**
  * Hide document content until reader is ready
  * todo: optimize performance and UX when loading stylebot reader
@@ -6,11 +26,24 @@
  */
 export const showLoader = (): void => {
   const style = document.createElement('style');
+  let cachedTheme: ReadabilityTheme | null = null;
+
+  try {
+    cachedTheme = localStorage.getItem(THEME_CACHE_KEY) as ReadabilityTheme | null;
+  } catch {
+    // localStorage may be unavailable; the loader just falls back to light.
+  }
+
+  const background = (cachedTheme && THEME_BACKGROUNDS[cachedTheme]) || THEME_BACKGROUNDS.light;
 
   style.type = 'text/css';
   style.setAttribute('id', 'stylebot-reader-loading');
   style.appendChild(
-    document.createTextNode('body *:not(#stylebot) { display: none; }')
+    document.createTextNode(
+      `html { background: ${background} !important; } ` +
+        'body { border: 0 !important; box-shadow: none !important; } ' +
+        'body *:not(#stylebot) { display: none; }'
+    )
   );
 
   document.documentElement.appendChild(style);

--- a/src/readability/reader.ts
+++ b/src/readability/reader.ts
@@ -12,7 +12,7 @@ import { cacheDocument } from './cache';
 const initCss = async (root: ShadowRoot): Promise<void> => {
   const cssUrl = chrome.runtime.getURL('readability/index.css');
 
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
     fetch(cssUrl, { method: 'GET' })
       .then(response => response.text())
       .then(css => {
@@ -21,7 +21,8 @@ const initCss = async (root: ShadowRoot): Promise<void> => {
         el.innerHTML = css;
         root.appendChild(el);
         resolve();
-      });
+      })
+      .catch(reject);
   });
 };
 
@@ -75,7 +76,7 @@ export const initReader = async (): Promise<void> => {
       const article = await getReadabilityArticle();
 
       cacheDocument();
-      initVueApp(url, source, article);
+      await initVueApp(url, source, article);
       resolve();
     } catch (e) {
       reject();

--- a/src/readability/utils.ts
+++ b/src/readability/utils.ts
@@ -1,4 +1,8 @@
 import Readability from 'readability';
+
+/* @ts-ignore */
+import { isProbablyReaderable } from '../../node_modules/readability/Readability-readerable';
+
 import { ReadabilityArticle } from '@stylebot/types';
 
 export const getDomainUrlAndSource = (): { url: string; source: string } => {
@@ -36,44 +40,28 @@ export const shouldRunOnUrl = (): boolean => {
   return true;
 };
 
+export const isReaderable = (): boolean => {
+  // Once mounted, the original content is stripped and the article lives
+  // in a shadow root `querySelectorAll` can't see — short-circuit instead.
+  if (document.getElementById('stylebot-reader')) {
+    return true;
+  }
+
+  return shouldRunOnUrl() && isProbablyReaderable(document);
+};
+
 /**
- * Fetch document object and apply readability
- *
- * Fetching url via XHR since document response is different v/s document loaded in browser.
- * same as https://dxr.mozilla.org/mozilla-central/source/toolkit/components/reader/ReaderMode.jsm#261
+ * Parse a clone of the live document — Readability mutates whatever it's
+ * given (strips scripts/styles etc.), so the original document must stay
+ * intact until reader mode is confirmed to apply.
  */
 export const getReadabilityArticle = async (): Promise<ReadabilityArticle> => {
-  return new Promise((resolve, reject) => {
-    const xhr = new XMLHttpRequest();
-    xhr.open('GET', window.location.href, true);
-    xhr.responseType = 'document';
+  const doc = document.cloneNode(true) as Document;
+  const article = new Readability(doc).parse();
 
-    xhr.onload = () => {
-      if (xhr.status !== 200) {
-        reject();
-        return;
-      }
+  if (!article?.content) {
+    throw new Error('Readability failed to parse the page');
+  }
 
-      const doc = xhr.responseXML;
-      if (!doc) {
-        reject();
-        return;
-      }
-
-      try {
-        const article = new Readability(doc).parse();
-
-        if (article.content) {
-          resolve(article);
-          return;
-        }
-
-        reject();
-      } catch (e) {
-        reject();
-      }
-    };
-
-    xhr.send();
-  });
+  return article;
 };

--- a/src/types/TabMessage.ts
+++ b/src/types/TabMessage.ts
@@ -30,6 +30,10 @@ export type GetIsStylebotOpen = {
   name: 'GetIsStylebotOpen';
 };
 
+export type GetIsPageReaderable = {
+  name: 'GetIsPageReaderable';
+};
+
 export type UpdateReader = {
   name: 'UpdateReader';
   value: ReadabilitySettings;
@@ -43,6 +47,7 @@ type TabMessage =
   | ApplyStylesToTab
   | TabUpdated
   | GetIsStylebotOpen
+  | GetIsPageReaderable
   | UpdateReader;
 
 export default TabMessage;


### PR DESCRIPTION
## Summary
- Fixes a blank-page bug: toggling readability on left the localStorage-cached page state stale, so a refresh right after enabling it could apply readability before the reader actually mounted. Also hardened the reader-mount chain (unawaited promises, no fetch timeouts) so a stall there can't blank the page either.
- Removes the loading flash: caches the last-used theme so the loading screen matches sepia/dark instead of flashing white, parses a clone of the live document instead of re-fetching the page over XHR, waits for the actual web font to load (Font Loading API) before revealing the reader, and resets the page's own body border/box-shadow behind the loader.
- The popup's readability toggle is now disabled on pages the reader can't apply to (e.g. a site's homepage), using the same applicability check the reader runs before mounting.

## Test plan
- [x] `yarn lint`
- [x] `yarn jest` (130 tests passing)
- [x] `yarn build`
- [x] Manually verified in dev Chrome: enable readability on an article, refresh (no longer blank), toggle sepia/dark theme (no white flash), popup toggle disabled on homepage / enabled on articles

🤖 Generated with [Claude Code](https://claude.com/claude-code)