### PR TITLE
Polish readability theming and fix page-eligibility bugs

### DIFF
--- a/src/background/__tests__/messages.test.ts
+++ b/src/background/__tests__/messages.test.ts
@@ -1,6 +1,6 @@
 jest.mock('../styles');
 
-import { SetReadability } from '../messages';
+import { SetReadability, ReadabilityActiveChanged } from '../messages';
 import * as stylesModule from '../styles';
 
 describe('SetReadability', () => {
@@ -12,9 +12,10 @@ describe('SetReadability', () => {
       styles: [],
       defaultStyle: { url: 'example.com', css: '', enabled: true, readability: true },
     });
+    (stylesModule.getIsReadabilityActive as jest.Mock).mockResolvedValue(true);
   });
 
-  it('persists the value and refreshes the badge for the sending tab', async () => {
+  it('persists the value and refreshes the badge with the live readability state', async () => {
     const tab = { id: 1, url: 'https://example.com/article' } as chrome.tabs.Tab;
 
     await SetReadability(
@@ -27,11 +28,8 @@ describe('SetReadability', () => {
       tab.url,
       expect.anything()
     );
-    expect(stylesModule.updateIcon).toBeCalledWith(
-      tab,
-      [],
-      expect.objectContaining({ readability: true })
-    );
+    expect(stylesModule.getIsReadabilityActive).toBeCalledWith(1);
+    expect(stylesModule.updateIcon).toBeCalledWith(tab, [], true);
   });
 
   it('does not attempt to update the badge when there is no sending tab', async () => {
@@ -41,6 +39,44 @@ describe('SetReadability', () => {
     );
 
     expect(stylesModule.setReadability).toBeCalledWith('example.com', true);
+    expect(stylesModule.updateIcon).not.toBeCalled();
+  });
+});
+
+describe('ReadabilityActiveChanged', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    (stylesModule.getAll as jest.Mock).mockResolvedValue({});
+    (stylesModule.getStylesForPage as jest.Mock).mockReturnValue({
+      styles: [],
+      defaultStyle: { url: 'example.com', css: '', enabled: true, readability: true },
+    });
+  });
+
+  it('re-queries the live state and refreshes the badge for the sending tab', async () => {
+    const tab = { id: 1, url: 'https://example.com/article' } as chrome.tabs.Tab;
+    (stylesModule.getIsReadabilityActive as jest.Mock).mockResolvedValue(true);
+
+    await ReadabilityActiveChanged({ name: 'ReadabilityActiveChanged' }, { tab });
+
+    expect(stylesModule.getIsReadabilityActive).toBeCalledWith(1);
+    expect(stylesModule.updateIcon).toBeCalledWith(tab, [], true);
+  });
+
+  it('reflects a false live answer even if a style is stored as readability:true', async () => {
+    const tab = { id: 1, url: 'https://example.com/main-page' } as chrome.tabs.Tab;
+    (stylesModule.getIsReadabilityActive as jest.Mock).mockResolvedValue(false);
+
+    await ReadabilityActiveChanged({ name: 'ReadabilityActiveChanged' }, { tab });
+
+    expect(stylesModule.updateIcon).toBeCalledWith(tab, [], false);
+  });
+
+  it('does nothing when there is no sending tab', async () => {
+    await ReadabilityActiveChanged({ name: 'ReadabilityActiveChanged' }, {});
+
+    expect(stylesModule.getIsReadabilityActive).not.toBeCalled();
     expect(stylesModule.updateIcon).not.toBeCalled();
   });
 });

--- a/src/background/__tests__/messages.test.ts
+++ b/src/background/__tests__/messages.test.ts
@@ -6,16 +6,9 @@ import * as stylesModule from '../styles';
 describe('SetReadability', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-
-    (stylesModule.getAll as jest.Mock).mockResolvedValue({});
-    (stylesModule.getStylesForPage as jest.Mock).mockReturnValue({
-      styles: [],
-      defaultStyle: { url: 'example.com', css: '', enabled: true, readability: true },
-    });
-    (stylesModule.getIsReadabilityActive as jest.Mock).mockResolvedValue(true);
   });
 
-  it('persists the value and refreshes the badge with the live readability state', async () => {
+  it('persists the value and refreshes the badge for the sending tab', async () => {
     const tab = { id: 1, url: 'https://example.com/article' } as chrome.tabs.Tab;
 
     await SetReadability(
@@ -24,12 +17,7 @@ describe('SetReadability', () => {
     );
 
     expect(stylesModule.setReadability).toBeCalledWith('example.com', true);
-    expect(stylesModule.getStylesForPage).toBeCalledWith(
-      tab.url,
-      expect.anything()
-    );
-    expect(stylesModule.getIsReadabilityActive).toBeCalledWith(1);
-    expect(stylesModule.updateIcon).toBeCalledWith(tab, [], true);
+    expect(stylesModule.refreshBadgeForTab).toBeCalledWith(tab);
   });
 
   it('does not attempt to update the badge when there is no sending tab', async () => {
@@ -39,44 +27,26 @@ describe('SetReadability', () => {
     );
 
     expect(stylesModule.setReadability).toBeCalledWith('example.com', true);
-    expect(stylesModule.updateIcon).not.toBeCalled();
+    expect(stylesModule.refreshBadgeForTab).not.toBeCalled();
   });
 });
 
 describe('ReadabilityActiveChanged', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-
-    (stylesModule.getAll as jest.Mock).mockResolvedValue({});
-    (stylesModule.getStylesForPage as jest.Mock).mockReturnValue({
-      styles: [],
-      defaultStyle: { url: 'example.com', css: '', enabled: true, readability: true },
-    });
   });
 
-  it('re-queries the live state and refreshes the badge for the sending tab', async () => {
+  it('refreshes the badge for the sending tab', async () => {
     const tab = { id: 1, url: 'https://example.com/article' } as chrome.tabs.Tab;
-    (stylesModule.getIsReadabilityActive as jest.Mock).mockResolvedValue(true);
 
     await ReadabilityActiveChanged({ name: 'ReadabilityActiveChanged' }, { tab });
 
-    expect(stylesModule.getIsReadabilityActive).toBeCalledWith(1);
-    expect(stylesModule.updateIcon).toBeCalledWith(tab, [], true);
-  });
-
-  it('reflects a false live answer even if a style is stored as readability:true', async () => {
-    const tab = { id: 1, url: 'https://example.com/main-page' } as chrome.tabs.Tab;
-    (stylesModule.getIsReadabilityActive as jest.Mock).mockResolvedValue(false);
-
-    await ReadabilityActiveChanged({ name: 'ReadabilityActiveChanged' }, { tab });
-
-    expect(stylesModule.updateIcon).toBeCalledWith(tab, [], false);
+    expect(stylesModule.refreshBadgeForTab).toBeCalledWith(tab);
   });
 
   it('does nothing when there is no sending tab', async () => {
     await ReadabilityActiveChanged({ name: 'ReadabilityActiveChanged' }, {});
 
-    expect(stylesModule.getIsReadabilityActive).not.toBeCalled();
-    expect(stylesModule.updateIcon).not.toBeCalled();
+    expect(stylesModule.refreshBadgeForTab).not.toBeCalled();
   });
 });

--- a/src/background/badge.ts
+++ b/src/background/badge.ts
@@ -1,0 +1,51 @@
+import { Style, GetIsReadabilityActive } from '@stylebot/types';
+
+// Asked live from the content script rather than tracked/persisted here,
+// so there's no stale cached value to race against.
+export const getIsReadabilityActive = (tabId: number): Promise<boolean> =>
+  new Promise(resolve => {
+    const message: GetIsReadabilityActive = { name: 'GetIsReadabilityActive' };
+
+    chrome.tabs.sendMessage(tabId, message, (response: boolean) => {
+      resolve(!!response);
+    });
+  });
+
+// Signals "styles are applied here" — readability doesn't need its own
+// color since the 📖 badge glyph already reads as distinct on its own.
+const STYLES_APPLIED_BADGE_COLOR = '#2e8b57';
+const DEFAULT_BADGE_COLOR = '#555';
+
+export const updateIcon = (
+  tab: chrome.tabs.Tab,
+  styles: Array<Style>,
+  readabilityActive: boolean
+): void => {
+  const enabledStyles = styles.filter(style => style.enabled);
+
+  if (readabilityActive) {
+    chrome.action.setBadgeBackgroundColor({
+      color: DEFAULT_BADGE_COLOR,
+      tabId: tab.id,
+    });
+    chrome.action.setBadgeText({
+      text: `📖`,
+      tabId: tab.id,
+    });
+  } else if (enabledStyles.length > 0) {
+    chrome.action.setBadgeBackgroundColor({
+      color: STYLES_APPLIED_BADGE_COLOR,
+      tabId: tab.id,
+    });
+    chrome.action.setBadgeText({
+      text: `${enabledStyles.length}`,
+      tabId: tab.id,
+    });
+  } else {
+    chrome.action.setBadgeBackgroundColor({
+      color: DEFAULT_BADGE_COLOR,
+      tabId: tab.id,
+    });
+    chrome.action.setBadgeText({ text: '', tabId: tab.id });
+  }
+};

--- a/src/background/listeners.ts
+++ b/src/background/listeners.ts
@@ -23,8 +23,7 @@ import {
   RunGoogleDriveSync,
 } from './messages';
 
-import { getAll, updateIcon, getIsReadabilityActive } from './styles';
-import { getStylesForPage } from '@stylebot/styles';
+import { refreshBadgeForTab } from './styles';
 import { get as getOption } from './options';
 
 import {
@@ -49,17 +48,11 @@ chrome.runtime.onInstalled.addListener(async ({ reason }) => {
 });
 
 /**
- * When an existing tab is updated, refresh the context-menu, badge and
- * action. The badge is refreshed here (rather than in response to the
- * content script's own initial styles lookup) since that lookup now reads
- * chrome.storage.local directly and no longer messages the background page.
+ * When an existing tab is updated, refresh the context-menu and badge.
  */
 chrome.tabs.onUpdated.addListener(async (tabId, _, tab) => {
   if (tab.status === 'complete' && tab.url) {
-    const allStyles = await getAll();
-    const { styles } = getStylesForPage(tab.url, allStyles);
-    const readabilityActive = await getIsReadabilityActive(tabId);
-    updateIcon(tab, styles, readabilityActive);
+    await refreshBadgeForTab(tab);
   }
 
   const option = await getOption('contextMenu');

--- a/src/background/listeners.ts
+++ b/src/background/listeners.ts
@@ -16,13 +16,14 @@ import {
   EnableStyle,
   DisableStyle,
   SetReadability,
+  ReadabilityActiveChanged,
   GetReadabilitySettings,
   SetReadabilitySettings,
   GetImportCss,
   RunGoogleDriveSync,
 } from './messages';
 
-import { getAll, updateIcon } from './styles';
+import { getAll, updateIcon, getIsReadabilityActive } from './styles';
 import { getStylesForPage } from '@stylebot/styles';
 import { get as getOption } from './options';
 
@@ -56,8 +57,9 @@ chrome.runtime.onInstalled.addListener(async ({ reason }) => {
 chrome.tabs.onUpdated.addListener(async (tabId, _, tab) => {
   if (tab.status === 'complete' && tab.url) {
     const allStyles = await getAll();
-    const { styles, defaultStyle } = getStylesForPage(tab.url, allStyles);
-    updateIcon(tab, styles, defaultStyle);
+    const { styles } = getStylesForPage(tab.url, allStyles);
+    const readabilityActive = await getIsReadabilityActive(tabId);
+    updateIcon(tab, styles, readabilityActive);
   }
 
   const option = await getOption('contextMenu');
@@ -143,6 +145,9 @@ chrome.runtime.onMessage.addListener(
 
       case 'SetReadability':
         SetReadability(message, sender);
+        break;
+      case 'ReadabilityActiveChanged':
+        ReadabilityActiveChanged(message, sender);
         break;
       case 'GetReadabilitySettings':
         GetReadabilitySettings(sendResponse);

--- a/src/background/messages.ts
+++ b/src/background/messages.ts
@@ -6,13 +6,13 @@ import {
   setAll,
   move,
   getStylesForPage,
-  updateIcon,
   setReadability,
-  getIsReadabilityActive,
   refreshBadgeForTab,
   getImportCss,
   applyStylesToAllTabs,
 } from './styles';
+
+import { getIsReadabilityActive, updateIcon } from './badge';
 
 import {
   get as getOption,

--- a/src/background/messages.ts
+++ b/src/background/messages.ts
@@ -8,6 +8,7 @@ import {
   getStylesForPage,
   updateIcon,
   setReadability,
+  getIsReadabilityActive,
   getImportCss,
   applyStylesToAllTabs,
 } from './styles';
@@ -29,6 +30,7 @@ import {
   SetAllStyles as SetAllStylesType,
   SetCommands as SetCommandsType,
   SetReadability as SetReadabilityType,
+  ReadabilityActiveChanged as ReadabilityActiveChangedType,
   SetReadabilitySettings as SetReadabilitySettingsType,
   GetImportCss as GetImportCssType,
   RunGoogleDriveSync as RunGoogleDriveSyncType,
@@ -93,8 +95,12 @@ export const GetStylesForPage = async (
   const styles = await getAll();
   const response = getStylesForPage(tab.url, styles, message.important);
 
-  updateIcon(tab, response.styles, response.defaultStyle);
   sendResponse(response);
+
+  if (tab.id !== undefined) {
+    const readabilityActive = await getIsReadabilityActive(tab.id);
+    updateIcon(tab, response.styles, readabilityActive);
+  }
 };
 
 export const MoveStyle = (message: MoveStyleType): void => {
@@ -146,13 +152,29 @@ export const SetReadability = async (
   await setReadability(message.url, message.value);
 
   const tab = sender.tab;
-  if (!tab || !tab.url) {
+  if (!tab || !tab.url || tab.id === undefined) {
     return;
   }
 
   const allStyles = await getAll();
-  const { styles, defaultStyle } = getStylesForPage(tab.url, allStyles);
-  updateIcon(tab, styles, defaultStyle);
+  const { styles } = getStylesForPage(tab.url, allStyles);
+  const readabilityActive = await getIsReadabilityActive(tab.id);
+  updateIcon(tab, styles, readabilityActive);
+};
+
+export const ReadabilityActiveChanged = async (
+  _message: ReadabilityActiveChangedType,
+  sender: chrome.runtime.MessageSender
+): Promise<void> => {
+  const tab = sender.tab;
+  if (!tab || !tab.url || tab.id === undefined) {
+    return;
+  }
+
+  const allStyles = await getAll();
+  const { styles } = getStylesForPage(tab.url, allStyles);
+  const readabilityActive = await getIsReadabilityActive(tab.id);
+  updateIcon(tab, styles, readabilityActive);
 };
 
 export const GetReadabilitySettings = async (

--- a/src/background/messages.ts
+++ b/src/background/messages.ts
@@ -9,6 +9,7 @@ import {
   updateIcon,
   setReadability,
   getIsReadabilityActive,
+  refreshBadgeForTab,
   getImportCss,
   applyStylesToAllTabs,
 } from './styles';
@@ -151,30 +152,18 @@ export const SetReadability = async (
 ): Promise<void> => {
   await setReadability(message.url, message.value);
 
-  const tab = sender.tab;
-  if (!tab || !tab.url || tab.id === undefined) {
-    return;
+  if (sender.tab) {
+    await refreshBadgeForTab(sender.tab);
   }
-
-  const allStyles = await getAll();
-  const { styles } = getStylesForPage(tab.url, allStyles);
-  const readabilityActive = await getIsReadabilityActive(tab.id);
-  updateIcon(tab, styles, readabilityActive);
 };
 
 export const ReadabilityActiveChanged = async (
   _message: ReadabilityActiveChangedType,
   sender: chrome.runtime.MessageSender
 ): Promise<void> => {
-  const tab = sender.tab;
-  if (!tab || !tab.url || tab.id === undefined) {
-    return;
+  if (sender.tab) {
+    await refreshBadgeForTab(sender.tab);
   }
-
-  const allStyles = await getAll();
-  const { styles } = getStylesForPage(tab.url, allStyles);
-  const readabilityActive = await getIsReadabilityActive(tab.id);
-  updateIcon(tab, styles, readabilityActive);
 };
 
 export const GetReadabilitySettings = async (

--- a/src/background/styles.ts
+++ b/src/background/styles.ts
@@ -8,9 +8,22 @@ import {
   StyleMap,
   StyleWithoutUrl,
   ApplyStylesToTab,
+  GetIsReadabilityActive,
 } from '@stylebot/types';
 
 export { getStylesForPage } from '@stylebot/styles';
+
+// Whether the reader is actually mounted on this tab right now — asked live
+// from the content script rather than tracked/persisted in the background,
+// so there's no stale cached value to race against.
+export const getIsReadabilityActive = (tabId: number): Promise<boolean> =>
+  new Promise(resolve => {
+    const message: GetIsReadabilityActive = { name: 'GetIsReadabilityActive' };
+
+    chrome.tabs.sendMessage(tabId, message, (response: boolean) => {
+      resolve(!!response);
+    });
+  });
 
 // Signals "styles are applied here" — readability doesn't need its own
 // color since the 📖 badge glyph already reads as distinct on its own.
@@ -20,11 +33,11 @@ const DEFAULT_BADGE_COLOR = '#555';
 export const updateIcon = (
   tab: chrome.tabs.Tab,
   styles: Array<Style>,
-  defaultStyle?: Style
+  readabilityActive: boolean
 ): void => {
   const enabledStyles = styles.filter(style => style.enabled);
 
-  if (defaultStyle && defaultStyle.readability) {
+  if (readabilityActive) {
     chrome.action.setBadgeBackgroundColor({
       color: DEFAULT_BADGE_COLOR,
       tabId: tab.id,
@@ -55,7 +68,7 @@ export const applyStylesToAllTabs = async (): Promise<void> => {
   const allStyles = await getAll();
 
   chrome.tabs.query({}, tabs => {
-    tabs.forEach(tab => {
+    tabs.forEach(async tab => {
       if (tab && tab.url && tab.id) {
         const { styles, defaultStyle } = getStylesForPage(tab.url, allStyles);
 
@@ -68,7 +81,8 @@ export const applyStylesToAllTabs = async (): Promise<void> => {
         chrome.tabs.sendMessage(tab.id, message);
 
         if (tab.active) {
-          updateIcon(tab, styles, defaultStyle);
+          const readabilityActive = await getIsReadabilityActive(tab.id);
+          updateIcon(tab, styles, readabilityActive);
         }
       }
     });

--- a/src/background/styles.ts
+++ b/src/background/styles.ts
@@ -3,65 +3,11 @@ import * as postcss from 'postcss';
 import { getCurrentTimestamp } from '@stylebot/utils';
 import { getStylesForPage } from '@stylebot/styles';
 
-import {
-  Style,
-  StyleMap,
-  StyleWithoutUrl,
-  ApplyStylesToTab,
-  GetIsReadabilityActive,
-} from '@stylebot/types';
+import { StyleMap, StyleWithoutUrl, ApplyStylesToTab } from '@stylebot/types';
+
+import { getIsReadabilityActive, updateIcon } from './badge';
 
 export { getStylesForPage } from '@stylebot/styles';
-
-// Asked live from the content script rather than tracked/persisted here,
-// so there's no stale cached value to race against.
-export const getIsReadabilityActive = (tabId: number): Promise<boolean> =>
-  new Promise(resolve => {
-    const message: GetIsReadabilityActive = { name: 'GetIsReadabilityActive' };
-
-    chrome.tabs.sendMessage(tabId, message, (response: boolean) => {
-      resolve(!!response);
-    });
-  });
-
-// Signals "styles are applied here" — readability doesn't need its own
-// color since the 📖 badge glyph already reads as distinct on its own.
-const STYLES_APPLIED_BADGE_COLOR = '#2e8b57';
-const DEFAULT_BADGE_COLOR = '#555';
-
-export const updateIcon = (
-  tab: chrome.tabs.Tab,
-  styles: Array<Style>,
-  readabilityActive: boolean
-): void => {
-  const enabledStyles = styles.filter(style => style.enabled);
-
-  if (readabilityActive) {
-    chrome.action.setBadgeBackgroundColor({
-      color: DEFAULT_BADGE_COLOR,
-      tabId: tab.id,
-    });
-    chrome.action.setBadgeText({
-      text: `📖`,
-      tabId: tab.id,
-    });
-  } else if (enabledStyles.length > 0) {
-    chrome.action.setBadgeBackgroundColor({
-      color: STYLES_APPLIED_BADGE_COLOR,
-      tabId: tab.id,
-    });
-    chrome.action.setBadgeText({
-      text: `${enabledStyles.length}`,
-      tabId: tab.id,
-    });
-  } else {
-    chrome.action.setBadgeBackgroundColor({
-      color: DEFAULT_BADGE_COLOR,
-      tabId: tab.id,
-    });
-    chrome.action.setBadgeText({ text: '', tabId: tab.id });
-  }
-};
 
 export const applyStylesToAllTabs = async (): Promise<void> => {
   const allStyles = await getAll();

--- a/src/background/styles.ts
+++ b/src/background/styles.ts
@@ -13,8 +13,7 @@ import {
 
 export { getStylesForPage } from '@stylebot/styles';
 
-// Whether the reader is actually mounted on this tab right now — asked live
-// from the content script rather than tracked/persisted in the background,
+// Asked live from the content script rather than tracked/persisted here,
 // so there's no stale cached value to race against.
 export const getIsReadabilityActive = (tabId: number): Promise<boolean> =>
   new Promise(resolve => {
@@ -87,6 +86,17 @@ export const applyStylesToAllTabs = async (): Promise<void> => {
       }
     });
   });
+};
+
+export const refreshBadgeForTab = async (tab: chrome.tabs.Tab): Promise<void> => {
+  if (!tab.url || tab.id === undefined) {
+    return;
+  }
+
+  const allStyles = await getAll();
+  const { styles } = getStylesForPage(tab.url, allStyles);
+  const readabilityActive = await getIsReadabilityActive(tab.id);
+  updateIcon(tab, styles, readabilityActive);
 };
 
 export const getAll = (): Promise<StyleMap> =>

--- a/src/background/styles.ts
+++ b/src/background/styles.ts
@@ -12,6 +12,11 @@ import {
 
 export { getStylesForPage } from '@stylebot/styles';
 
+// Signals "styles are applied here" — readability doesn't need its own
+// color since the 📖 badge glyph already reads as distinct on its own.
+const STYLES_APPLIED_BADGE_COLOR = '#2e8b57';
+const DEFAULT_BADGE_COLOR = '#555';
+
 export const updateIcon = (
   tab: chrome.tabs.Tab,
   styles: Array<Style>,
@@ -20,16 +25,28 @@ export const updateIcon = (
   const enabledStyles = styles.filter(style => style.enabled);
 
   if (defaultStyle && defaultStyle.readability) {
+    chrome.action.setBadgeBackgroundColor({
+      color: DEFAULT_BADGE_COLOR,
+      tabId: tab.id,
+    });
     chrome.action.setBadgeText({
-      text: `R`,
+      text: `📖`,
       tabId: tab.id,
     });
   } else if (enabledStyles.length > 0) {
+    chrome.action.setBadgeBackgroundColor({
+      color: STYLES_APPLIED_BADGE_COLOR,
+      tabId: tab.id,
+    });
     chrome.action.setBadgeText({
       text: `${enabledStyles.length}`,
       tabId: tab.id,
     });
   } else {
+    chrome.action.setBadgeBackgroundColor({
+      color: DEFAULT_BADGE_COLOR,
+      tabId: tab.id,
+    });
     chrome.action.setBadgeText({ text: '', tabId: tab.id });
   }
 };

--- a/src/editor/components/footer/TheEditorModeActions.vue
+++ b/src/editor/components/footer/TheEditorModeActions.vue
@@ -4,6 +4,7 @@
       size="sm"
       :title="`${t('basic_mode_description')} (b)`"
       :variant="mode === 'basic' ? 'secondary' : 'outline-secondary'"
+      :disabled="readability"
       @click="setMode('basic')"
     >
       <b-icon icon="image" aria-hidden="true" />
@@ -14,6 +15,7 @@
       size="sm"
       :title="`${t('code_mode_description')} (c)`"
       :variant="mode === 'code' ? 'secondary' : 'outline-secondary'"
+      :disabled="readability"
       @click="setMode('code')"
     >
       <b-icon icon="code" aria-hidden="true" />
@@ -35,12 +37,21 @@
 <script lang="ts">
 import Vue from 'vue';
 
+import { isReaderable } from '@stylebot/readability';
+
 export default Vue.extend({
   name: 'TheEditorModeActions',
 
   computed: {
     mode(): string {
       return this.$store.state.options.mode;
+    },
+
+    // state.readability alone can be true domain-wide while this specific
+    // page doesn't qualify (e.g. a MediaWiki main page) — isReaderable()
+    // also short-circuits true when the reader is already mounted.
+    readability(): boolean {
+      return isReaderable() && this.$store.state.readability;
     },
   },
 

--- a/src/editor/components/footer/TheEditorModeActions.vue
+++ b/src/editor/components/footer/TheEditorModeActions.vue
@@ -37,8 +37,6 @@
 <script lang="ts">
 import Vue from 'vue';
 
-import { isReaderable } from '@stylebot/readability';
-
 export default Vue.extend({
   name: 'TheEditorModeActions',
 
@@ -47,11 +45,8 @@ export default Vue.extend({
       return this.$store.state.options.mode;
     },
 
-    // state.readability alone can be true domain-wide while this specific
-    // page doesn't qualify (e.g. a MediaWiki main page) — isReaderable()
-    // also short-circuits true when the reader is already mounted.
     readability(): boolean {
-      return isReaderable() && this.$store.state.readability;
+      return this.$store.getters.readabilityActive;
     },
   },
 

--- a/src/editor/components/magic/TheReadability.vue
+++ b/src/editor/components/magic/TheReadability.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="the-readability">
-    <b-form-checkbox v-model="value" switch class="enable-readability">
+    <b-form-checkbox
+      v-model="value"
+      switch
+      class="enable-readability"
+      :disabled="!pageReaderable"
+    >
       {{ t('enable_readability') }}
     </b-form-checkbox>
 
@@ -57,6 +62,8 @@
 <script lang="ts">
 import Vue from 'vue';
 
+import { isReaderable } from '@stylebot/readability';
+
 import CssProperty from '../CssProperty.vue';
 import CssPropertyValue from '../CssPropertyValue.vue';
 
@@ -80,9 +87,13 @@ export default Vue.extend({
   },
 
   computed: {
+    pageReaderable(): boolean {
+      return isReaderable();
+    },
+
     value: {
       get(): boolean {
-        return this.$store.state.readability;
+        return this.pageReaderable && this.$store.state.readability;
       },
 
       set(value: boolean): void {

--- a/src/editor/components/magic/TheReadability.vue
+++ b/src/editor/components/magic/TheReadability.vue
@@ -93,7 +93,7 @@ export default Vue.extend({
 
     value: {
       get(): boolean {
-        return this.pageReaderable && this.$store.state.readability;
+        return this.$store.getters.readabilityActive;
       },
 
       set(value: boolean): void {

--- a/src/editor/components/magic/readability/TheReadabilityFontFamily.vue
+++ b/src/editor/components/magic/readability/TheReadabilityFontFamily.vue
@@ -5,7 +5,9 @@
       :fonts="fonts"
       :disabled="disabled"
       hide-default
+      hide-edit-font-list
       @select="select"
+      @preview="preview"
     />
   </b-input-group>
 </template>
@@ -14,6 +16,8 @@
 import Vue from 'vue';
 
 import { StylebotFonts } from '@stylebot/types';
+import { readabilityFonts } from '@stylebot/settings';
+import { previewReaderFont } from '@stylebot/readability';
 
 import FontFamilyDropdown from '../../text/FontFamilyDropdown.vue';
 
@@ -43,7 +47,7 @@ export default Vue.extend({
     },
 
     fonts(): StylebotFonts {
-      return this.$store.state.options.fonts;
+      return readabilityFonts;
     },
   },
 
@@ -53,6 +57,10 @@ export default Vue.extend({
         ...this.$store.state.readabilitySettings,
         font: value,
       });
+    },
+
+    preview(font: string | null): void {
+      previewReaderFont(font);
     },
 
     focus(event: FocusEvent): void {

--- a/src/editor/components/magic/readability/TheReadabilityFontFamily.vue
+++ b/src/editor/components/magic/readability/TheReadabilityFontFamily.vue
@@ -16,8 +16,7 @@
 import Vue from 'vue';
 
 import { StylebotFonts } from '@stylebot/types';
-import { readabilityFonts } from '@stylebot/settings';
-import { previewReaderFont } from '@stylebot/readability';
+import { readabilityFonts, previewReaderFont } from '@stylebot/readability';
 
 import FontFamilyDropdown from '../../text/FontFamilyDropdown.vue';
 

--- a/src/editor/components/text/FontFamilyDropdown.vue
+++ b/src/editor/components/text/FontFamilyDropdown.vue
@@ -8,6 +8,7 @@
         :disabled="disabled"
         variant="outline-secondary"
         class="font-family-dropdown"
+        @hide="$emit('preview', null)"
       >
         <b-dropdown-item v-if="!hideDefault" @click="$emit('select', '')">
           {{ t('default') }}
@@ -17,11 +18,13 @@
           v-for="font in fonts"
           :key="font"
           @click="$emit('select', font)"
+          @mouseenter.native="$emit('preview', font)"
+          @mouseleave.native="$emit('preview', null)"
         >
           {{ font }}
         </b-dropdown-item>
 
-        <b-dropdown-item @click="editFonts">
+        <b-dropdown-item v-if="!hideEditFontList" @click="editFonts">
           {{ t('fonts_edit_list') }}
         </b-dropdown-item>
       </b-dropdown>
@@ -58,6 +61,10 @@ export default Vue.extend({
       required: true,
     },
     hideDefault: {
+      type: Boolean,
+      required: false,
+    },
+    hideEditFontList: {
       type: Boolean,
       required: false,
     },

--- a/src/editor/listeners/chrome.ts
+++ b/src/editor/listeners/chrome.ts
@@ -20,10 +20,8 @@ import { getStylesForPage } from '../utils/chrome';
 const initChromeListener = (store: Store<State>): void => {
   const { state, commit, dispatch } = store;
 
-  // chrome.tabs.onUpdated (and so 'TabUpdated') also fires for favicon/title
-  // changes with no navigation — only re-derive readability when the URL
-  // actually changed, so those don't race a just-persisted toggle. Starts
-  // null so the first 'TabUpdated' for this page load isn't skipped too.
+  // Re-derive readability only on real URL changes, not favicon/title-only
+  // TabUpdated events — null so the first event here still runs.
   let lastUrl: string | null = null;
 
   chrome.runtime.onMessage.addListener(

--- a/src/editor/listeners/chrome.ts
+++ b/src/editor/listeners/chrome.ts
@@ -3,7 +3,10 @@ import { Store } from 'vuex';
 import { State } from 'editor/store';
 import { TabMessage } from '@stylebot/types';
 
-import { apply as applyReadability } from '@stylebot/readability';
+import {
+  apply as applyReadability,
+  remove as removeReadability,
+} from '@stylebot/readability';
 
 import {
   applyStyles,
@@ -12,8 +15,16 @@ import {
   updateSelectorWithContextMenuSelector,
 } from './common';
 
+import { getStylesForPage } from '../utils/chrome';
+
 const initChromeListener = (store: Store<State>): void => {
   const { state, commit, dispatch } = store;
+
+  // chrome.tabs.onUpdated (and so 'TabUpdated') also fires for favicon/title
+  // changes with no navigation — only re-derive readability when the URL
+  // actually changed, so those don't race a just-persisted toggle. Starts
+  // null so the first 'TabUpdated' for this page load isn't skipped too.
+  let lastUrl: string | null = null;
 
   chrome.runtime.onMessage.addListener(
     (message: TabMessage, _, sendResponse: (response: boolean) => void) => {
@@ -36,9 +47,23 @@ const initChromeListener = (store: Store<State>): void => {
       } else if (message.name === 'GetIsStylebotOpen') {
         sendResponse(state.visible);
       } else if (message.name === 'TabUpdated') {
-        if (state.readability) {
-          applyReadability();
+        if (window.location.href === lastUrl) {
+          return;
         }
+        lastUrl = window.location.href;
+
+        // A same-tab SPA navigation still fires this — re-derive readability
+        // for the new URL instead of trusting the previous page's flag.
+        getStylesForPage(false).then(({ defaultStyle }) => {
+          const readability = Boolean(defaultStyle?.readability);
+          commit('setReadability', readability);
+
+          if (readability) {
+            applyReadability();
+          } else {
+            removeReadability();
+          }
+        });
       } else if (message.name === 'ToggleReadabilityForTab') {
         toggleReadability({ state, dispatch });
       } else if (message.name === 'ApplyStylesToTab') {

--- a/src/editor/store/__tests__/actions.test.ts
+++ b/src/editor/store/__tests__/actions.test.ts
@@ -138,7 +138,10 @@ describe('actions', () => {
     });
 
     it('does nothing to the cache when nothing is cached yet', () => {
-      actions.applyReadability({ commit: mockCommit, state: mockState }, true);
+      actions.applyReadability(
+        { commit: mockCommit, state: mockState, dispatch: mockDispatch },
+        true
+      );
 
       expect(readCache()).toBeNull();
     });
@@ -149,7 +152,10 @@ describe('actions', () => {
         readability: false,
       });
 
-      actions.applyReadability({ commit: mockCommit, state: mockState }, true);
+      actions.applyReadability(
+        { commit: mockCommit, state: mockState, dispatch: mockDispatch },
+        true
+      );
 
       expect(readCache()).toEqual({
         styles: [{ url: mockState.url, css: 'a { color: blue; }', enabled: true }],
@@ -157,6 +163,37 @@ describe('actions', () => {
       });
       expect(stylebotReadability.apply).toBeCalledWith(true);
       expect(chromeUtils.setReadability).toBeCalledWith(mockState.url, true);
+    });
+
+    it('switches out of basic/code mode since editing page CSS has no effect there', () => {
+      actions.applyReadability(
+        { commit: mockCommit, state: mockState, dispatch: mockDispatch },
+        true
+      );
+
+      expect(mockDispatch).toBeCalledWith('setMode', 'magic');
+    });
+
+    it('leaves the mode alone when turning readability off', () => {
+      actions.applyReadability(
+        { commit: mockCommit, state: mockState, dispatch: mockDispatch },
+        false
+      );
+
+      expect(mockDispatch).not.toBeCalledWith('setMode', 'magic');
+    });
+
+    it('leaves the mode alone when already in magic mode', () => {
+      actions.applyReadability(
+        {
+          commit: mockCommit,
+          state: { ...mockState, options: { ...mockState.options, mode: 'magic' } },
+          dispatch: mockDispatch,
+        },
+        true
+      );
+
+      expect(mockDispatch).not.toBeCalledWith('setMode', 'magic');
     });
   });
 

--- a/src/editor/store/actions.ts
+++ b/src/editor/store/actions.ts
@@ -1,5 +1,5 @@
 import * as postcss from 'postcss';
-import { Commit, Dispatch, Store } from 'vuex';
+import { Commit, Dispatch, GetterTree, Store } from 'vuex';
 
 import { State } from './';
 
@@ -96,7 +96,11 @@ export default {
   },
 
   openStylebot(
-    { state, commit }: { state: State; commit: Commit },
+    {
+      state,
+      commit,
+      getters,
+    }: { state: State; commit: Commit; getters: GetterTree<State, State> },
     { inspect = false, store }: { inspect: boolean; store: Store<State> }
   ): void {
     initEditor(store);
@@ -106,6 +110,13 @@ export default {
     }
 
     commit('setVisible', true);
+
+    // Editing page CSS has no effect while readability is running — show
+    // the Magic panel instead, without persisting over the user's actual
+    // mode preference for when they open Stylebot elsewhere.
+    if (getters.readabilityActive && state.options.mode !== 'magic') {
+      commit('setOptions', { ...state.options, mode: 'magic' });
+    }
 
     if (state.options.mode === 'basic' && inspect) {
       commit('setInspecting', true);

--- a/src/editor/store/actions.ts
+++ b/src/editor/store/actions.ts
@@ -226,13 +226,23 @@ export default {
   },
 
   applyReadability(
-    { state, commit }: { state: State; commit: Commit },
+    {
+      state,
+      commit,
+      dispatch,
+    }: { state: State; commit: Commit; dispatch: Dispatch },
     value: boolean
   ): void {
     if (value) {
       applyReadability(true);
     } else {
       removeReadability();
+    }
+
+    // Editing page CSS has no effect while readability is running — its DOM
+    // is detached from the document, not just hidden.
+    if (value && ['basic', 'code'].includes(state.options.mode)) {
+      dispatch('setMode', 'magic');
     }
 
     commit('setReadability', value);

--- a/src/editor/store/actions.ts
+++ b/src/editor/store/actions.ts
@@ -1,7 +1,12 @@
 import * as postcss from 'postcss';
-import { Commit, Dispatch, GetterTree, Store } from 'vuex';
+import { Commit, Dispatch, Store } from 'vuex';
 
 import { State } from './';
+import storeGetters from './getters';
+
+type Getters = {
+  [K in keyof typeof storeGetters]: ReturnType<(typeof storeGetters)[K]>;
+};
 
 import {
   addDeclaration,
@@ -100,7 +105,7 @@ export default {
       state,
       commit,
       getters,
-    }: { state: State; commit: Commit; getters: GetterTree<State, State> },
+    }: { state: State; commit: Commit; getters: Getters },
     { inspect = false, store }: { inspect: boolean; store: Store<State> }
   ): void {
     initEditor(store);
@@ -111,9 +116,8 @@ export default {
 
     commit('setVisible', true);
 
-    // Editing page CSS has no effect while readability is running — show
-    // the Magic panel instead, without persisting over the user's actual
-    // mode preference for when they open Stylebot elsewhere.
+    // Show Magic instead of the useless Basic/Code panel, without
+    // persisting over the user's actual mode preference elsewhere.
     if (getters.readabilityActive && state.options.mode !== 'magic') {
       commit('setOptions', { ...state.options, mode: 'magic' });
     }

--- a/src/editor/store/getters.ts
+++ b/src/editor/store/getters.ts
@@ -17,9 +17,8 @@ export default {
     return getFilterEffectValueForPage('grayscale', state.css);
   },
 
-  // state.readability alone can be true domain-wide while this specific
-  // page doesn't actually qualify (e.g. a wiki's main page) — isReaderable()
-  // also accounts for whether the reader is already mounted.
+  // state.readability alone can be true domain-wide while this page
+  // doesn't actually qualify (e.g. a wiki's main page).
   readabilityActive: (state: State): boolean => {
     return state.readability && isReaderable();
   },

--- a/src/editor/store/getters.ts
+++ b/src/editor/store/getters.ts
@@ -2,6 +2,7 @@ import * as postcss from 'postcss';
 
 import { State } from './';
 import { getRule, getFilterEffectValueForPage } from '@stylebot/css';
+import { isReaderable } from '@stylebot/readability';
 
 export default {
   activeRule: (state: State): postcss.Rule | null => {
@@ -14,5 +15,12 @@ export default {
 
   grayscale: (state: State): number => {
     return getFilterEffectValueForPage('grayscale', state.css);
+  },
+
+  // state.readability alone can be true domain-wide while this specific
+  // page doesn't actually qualify (e.g. a wiki's main page) — isReaderable()
+  // also accounts for whether the reader is already mounted.
+  readabilityActive: (state: State): boolean => {
+    return state.readability && isReaderable();
   },
 };

--- a/src/inject-css/__tests__/index.test.ts
+++ b/src/inject-css/__tests__/index.test.ts
@@ -12,6 +12,11 @@ describe('inject-css run()', () => {
   let cacheModule: typeof import('../cache');
   let hidePageModule: typeof import('../hide-page');
   let stylesModule: typeof import('@stylebot/styles');
+  let registeredListener: (
+    message: { name: string },
+    sender: unknown,
+    sendResponse: (response: boolean) => void
+  ) => void;
 
   beforeEach(() => {
     jest.resetModules();
@@ -25,7 +30,13 @@ describe('inject-css run()', () => {
 
     (global as any).chrome = {
       storage: { local: { get: jest.fn() } },
-      runtime: { onMessage: { addListener: jest.fn() } },
+      runtime: {
+        onMessage: {
+          addListener: (fn: typeof registeredListener) => {
+            registeredListener = fn;
+          },
+        },
+      },
     };
   });
 
@@ -140,5 +151,28 @@ describe('inject-css run()', () => {
       styles: [],
       readability: true,
     });
+  });
+
+  it('answers GetIsReadabilityActive based on whether #stylebot-reader is mounted', () => {
+    (cacheModule.readCache as jest.Mock).mockReturnValue(null);
+    (stylesModule.getStylesForPage as jest.Mock).mockReturnValue({
+      styles: [],
+      defaultStyle: undefined,
+    });
+
+    load({ styles: {} });
+
+    const sendResponse = jest.fn();
+    registeredListener({ name: 'GetIsReadabilityActive' }, {}, sendResponse);
+    expect(sendResponse).toHaveBeenLastCalledWith(false);
+
+    const host = document.createElement('div');
+    host.id = 'stylebot-reader';
+    document.body.appendChild(host);
+
+    registeredListener({ name: 'GetIsReadabilityActive' }, {}, sendResponse);
+    expect(sendResponse).toHaveBeenLastCalledWith(true);
+
+    host.remove();
   });
 });

--- a/src/inject-css/index.ts
+++ b/src/inject-css/index.ts
@@ -19,6 +19,8 @@ if (window === window.top) {
     (message: TabMessage, _sender, sendResponse: (response: boolean) => void) => {
       if (message.name === 'GetIsPageReaderable') {
         sendResponse(isReaderable());
+      } else if (message.name === 'GetIsReadabilityActive') {
+        sendResponse(!!document.getElementById('stylebot-reader'));
       }
     }
   );

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -5,13 +5,14 @@
         v-for="style in styles"
         :key="style.url"
         :url="style.url"
-        :disable-toggle="isOpen"
+        :disable-toggle="isOpen || (pageReaderable && readability)"
         :initial-enabled="style.enabled"
       />
 
       <readability
-        :initial-readability="readability"
+        :initial-readability="pageReaderable && readability"
         :disabled="!pageReaderable"
+        @change="readability = $event"
       />
 
       <toggle-stylebot :is-open="isOpen" :tab="tab" />

--- a/src/popup/components/Readability.vue
+++ b/src/popup/components/Readability.vue
@@ -60,6 +60,8 @@ export default Vue.extend({
     },
 
     onChange(): void {
+      this.$emit('change', this.readability);
+
       chrome.tabs.query({ active: true }, ([tab]) => {
         if (tab.id) {
           const message: ToggleReadabilityForTab = {

--- a/src/readability/__tests__/apply.test.ts
+++ b/src/readability/__tests__/apply.test.ts
@@ -1,7 +1,7 @@
 export {};
 
 jest.mock('../reader');
-jest.mock('../utils');
+jest.mock('../heuristics');
 jest.mock('../loader');
 jest.mock('../cache');
 
@@ -9,7 +9,7 @@ const flushPromises = () => new Promise(resolve => setImmediate(resolve));
 
 describe('readability apply()/remove()', () => {
   let readerModule: typeof import('../reader');
-  let utilsModule: typeof import('../utils');
+  let heuristicsModule: typeof import('../heuristics');
   let loaderModule: typeof import('../loader');
   let cacheModule: typeof import('../cache');
   let apply: typeof import('../apply').apply;
@@ -27,12 +27,12 @@ describe('readability apply()/remove()', () => {
     jest.useFakeTimers();
 
     readerModule = require('../reader');
-    utilsModule = require('../utils');
+    heuristicsModule = require('../heuristics');
     loaderModule = require('../loader');
     cacheModule = require('../cache');
 
     (cacheModule.didUrlChange as jest.Mock).mockReturnValue(true);
-    (utilsModule.shouldRunOnUrl as jest.Mock).mockReturnValue(true);
+    (heuristicsModule.shouldRunOnUrl as jest.Mock).mockReturnValue(true);
     (readerModule.initReader as jest.Mock).mockResolvedValue(undefined);
 
     setReadyState('complete');
@@ -54,7 +54,7 @@ describe('readability apply()/remove()', () => {
   });
 
   it('reverts and skips mounting when the url should not run', async () => {
-    (utilsModule.shouldRunOnUrl as jest.Mock).mockReturnValue(false);
+    (heuristicsModule.shouldRunOnUrl as jest.Mock).mockReturnValue(false);
 
     await apply();
 
@@ -84,6 +84,17 @@ describe('readability apply()/remove()', () => {
     await flushPromises();
 
     expect(readerModule.initReader).toBeCalledTimes(1);
+  });
+
+  it('reverts immediately without retrying on a MediaWiki main page', async () => {
+    (heuristicsModule.isMediaWikiMainPage as jest.Mock).mockReturnValue(true);
+
+    await apply();
+    await flushPromises();
+
+    expect(readerModule.initReader).not.toBeCalled();
+    expect(loaderModule.hideLoader).toBeCalled();
+    expect(cacheModule.revertToCachedDocument).toBeCalled();
   });
 
   it('retries a bounded number of times before giving up', async () => {

--- a/src/readability/__tests__/apply.test.ts
+++ b/src/readability/__tests__/apply.test.ts
@@ -26,6 +26,10 @@ describe('readability apply()/remove()', () => {
     jest.resetModules();
     jest.useFakeTimers();
 
+    global.chrome = {
+      runtime: { sendMessage: jest.fn() },
+    } as unknown as typeof chrome;
+
     readerModule = require('../reader');
     heuristicsModule = require('../heuristics');
     loaderModule = require('../loader');

--- a/src/readability/apply.ts
+++ b/src/readability/apply.ts
@@ -1,5 +1,5 @@
 import { initReader } from './reader';
-import { shouldRunOnUrl } from './utils';
+import { shouldRunOnUrl, isMediaWikiMainPage } from './heuristics';
 import { showLoader, hideLoader } from './loader';
 import { cacheUrl, didUrlChange, revertToCachedDocument } from './cache';
 
@@ -18,6 +18,18 @@ const clearPendingRetry = (): void => {
     clearTimeout(pendingRetry);
     pendingRetry = null;
   }
+};
+
+// Checked once when the DOM is ready, not retried like initReader()'s
+// Mozilla heuristic — waiting longer won't change whether this is the
+// wiki's main page, so retrying would just delay revealing the real page.
+const startIfEligible = (myGeneration: number): void => {
+  if (isMediaWikiMainPage()) {
+    remove();
+    return;
+  }
+
+  run(myGeneration);
 };
 
 const run = async (myGeneration: number, attempt = 0): Promise<void> => {
@@ -70,17 +82,32 @@ export const apply = async (forceApply = false): Promise<void> => {
   // mid-load) means it never fires, leaving the loader up forever.
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', () => {
-      run(myGeneration);
+      startIfEligible(myGeneration);
     });
   } else {
-    run(myGeneration);
+    startIfEligible(myGeneration);
   }
 };
+
+// Kept in sync with the `.stylebot-reader.closing` transition duration.
+const CLOSE_TRANSITION_MS = 250;
 
 export const remove = (): void => {
   generation++;
   clearPendingRetry();
   hideLoader();
   revertToCachedDocument();
-  document.getElementById('stylebot-reader')?.remove();
+
+  const host = document.getElementById('stylebot-reader');
+  const panel = host?.shadowRoot?.querySelector<HTMLElement>('.stylebot-reader');
+
+  if (!panel) {
+    host?.remove();
+    return;
+  }
+
+  // The original page is already back underneath — fade the panel out
+  // before detaching it instead of cutting away abruptly.
+  panel.classList.add('closing');
+  setTimeout(() => host?.remove(), CLOSE_TRANSITION_MS);
 };

--- a/src/readability/apply.ts
+++ b/src/readability/apply.ts
@@ -3,6 +3,16 @@ import { shouldRunOnUrl, isMediaWikiMainPage } from './heuristics';
 import { showLoader, hideLoader } from './loader';
 import { cacheUrl, didUrlChange, revertToCachedDocument } from './cache';
 
+import { ReadabilityActiveChanged } from '@stylebot/types';
+
+// Tells the background to refresh the badge — carries no state itself, the
+// background re-queries the live DOM (GetIsReadabilityActive), so there's
+// no stale value to race against.
+const reportChanged = (): void => {
+  const message: ReadabilityActiveChanged = { name: 'ReadabilityActiveChanged' };
+  chrome.runtime.sendMessage(message);
+};
+
 // Client-rendered pages can still be empty right after load — retry a few
 // times before giving up, so hydration has a chance to finish.
 export const RETRY_DELAYS_MS = [300, 600, 1200];
@@ -39,6 +49,7 @@ const run = async (myGeneration: number, attempt = 0): Promise<void> => {
 
   try {
     await initReader();
+    reportChanged();
   } catch (e) {
     if (myGeneration !== generation) {
       return;
@@ -103,11 +114,15 @@ export const remove = (): void => {
 
   if (!panel) {
     host?.remove();
+    reportChanged();
     return;
   }
 
   // The original page is already back underneath — fade the panel out
   // before detaching it instead of cutting away abruptly.
   panel.classList.add('closing');
-  setTimeout(() => host?.remove(), CLOSE_TRANSITION_MS);
+  setTimeout(() => {
+    host?.remove();
+    reportChanged();
+  }, CLOSE_TRANSITION_MS);
 };

--- a/src/readability/apply.ts
+++ b/src/readability/apply.ts
@@ -5,9 +5,8 @@ import { cacheUrl, didUrlChange, revertToCachedDocument } from './cache';
 
 import { ReadabilityActiveChanged } from '@stylebot/types';
 
-// Tells the background to refresh the badge — carries no state itself, the
-// background re-queries the live DOM (GetIsReadabilityActive), so there's
-// no stale value to race against.
+// Tells the background to refresh the badge — carries no state itself,
+// it re-queries the live DOM instead of trusting a passed value.
 const reportChanged = (): void => {
   const message: ReadabilityActiveChanged = { name: 'ReadabilityActiveChanged' };
   chrome.runtime.sendMessage(message);
@@ -30,9 +29,8 @@ const clearPendingRetry = (): void => {
   }
 };
 
-// Checked once when the DOM is ready, not retried like initReader()'s
-// Mozilla heuristic — waiting longer won't change whether this is the
-// wiki's main page, so retrying would just delay revealing the real page.
+// Checked once, not retried like initReader()'s heuristic — more waiting
+// won't change whether this is the wiki's main page.
 const startIfEligible = (myGeneration: number): void => {
   if (isMediaWikiMainPage()) {
     remove();

--- a/src/readability/components/TheReader.vue
+++ b/src/readability/components/TheReader.vue
@@ -1,8 +1,8 @@
 <template>
   <div
     v-if="font"
-    :class="`stylebot-reader ${theme}`"
-    :style="`font-family: ${font}; font-size: ${size}px; line-height: ${lineHeight}em`"
+    :class="[`stylebot-reader ${theme}`, { revealed }]"
+    :style="`font-family: ${previewFont || font}; font-size: ${size}px; line-height: ${lineHeight}em`"
   >
     <div class="stylebot-reader-body" :style="`max-width: ${width}em`">
       <the-reader-header
@@ -29,6 +29,7 @@ import {
 } from '@stylebot/css';
 
 import { hideLoader, cacheTheme } from '../loader';
+import { onPreviewReaderFont } from '../preview';
 
 import {
   GetReadabilitySettings,
@@ -69,8 +70,10 @@ export default Vue.extend({
     width: number;
     lineHeight: number;
     theme: ReadabilityTheme;
+    revealed: boolean;
+    previewFont: string | null;
   } {
-    return defaultReadabilitySettings;
+    return { ...defaultReadabilitySettings, revealed: false, previewFont: null };
   },
 
   async mounted(): Promise<void> {
@@ -94,6 +97,11 @@ export default Vue.extend({
       // Always reveal the reader — the original page is already gone,
       // so a stalled/failed fetch here would otherwise blank the page.
       hideLoader();
+
+      // The reader was just unhidden and never painted — force a reflow so
+      // the pre-fade style commits before we transition it.
+      void (this.$el as HTMLElement).offsetHeight;
+      this.revealed = true;
     }
 
     chrome.runtime.onMessage.addListener((message: UpdateReader) => {
@@ -106,6 +114,14 @@ export default Vue.extend({
 
         cacheTheme(message.value.theme);
         this.injectFont(this.font);
+      }
+    });
+
+    onPreviewReaderFont(font => {
+      this.previewFont = font;
+
+      if (font) {
+        this.injectFont(font);
       }
     });
   },

--- a/src/readability/components/TheReaderHeader.vue
+++ b/src/readability/components/TheReaderHeader.vue
@@ -44,26 +44,37 @@ export default Vue.extend({
 .stylebot-reader-header {
   > h1 {
     font-size: 1.6em;
-    line-height: 1.25em;
+    line-height: 1.3em;
+    font-weight: 700;
     width: 100%;
-    margin-top: 30px;
+    margin-top: 24px;
     margin-bottom: 10px;
     padding: 0;
   }
 }
 
 .stylebot-reader-domain {
-  font-size: 0.9em;
-  line-height: 1.48em;
+  display: inline-block;
+  font-size: 0.85em;
+  line-height: 1.4em;
   padding-bottom: 4px;
   text-decoration: none;
-  border-bottom: 1px solid #333;
-  color: #45a1ff;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted-foreground);
+  border-bottom: 1px solid var(--border-color);
+  transition: color 0.15s ease, border-color 0.15s ease;
+
+  &:hover {
+    color: var(--link-color);
+    border-color: var(--link-color);
+  }
 }
 
 .stylebot-reader-byline {
   font-size: 1em;
   font-weight: 300;
+  color: var(--muted-foreground);
   margin-bottom: 30px;
 }
 </style>

--- a/src/readability/fonts.ts
+++ b/src/readability/fonts.ts
@@ -1,0 +1,10 @@
+import { StylebotFonts } from '@stylebot/types';
+
+// Kept apart from `defaultOptions.fonts`, which also powers the
+// general-purpose Text panel and needs display/code fonts too.
+export const readabilityFonts: StylebotFonts = [
+  'Merriweather',
+  'Georgia',
+  'Lora',
+  'Helvetica',
+];

--- a/src/readability/heuristics.ts
+++ b/src/readability/heuristics.ts
@@ -1,0 +1,73 @@
+import { isProbablyReaderable } from '@mozilla/readability';
+
+// A single short, barely-hyphenated path segment reads as a section/category
+// name (e.g. "tech", "news") rather than a full article slug.
+const looksLikeSectionPath = (pathname: string): boolean => {
+  const segments = pathname.split('/').filter(Boolean);
+
+  if (segments.length !== 1) {
+    return false;
+  }
+
+  const [segment] = segments;
+  const hyphenCount = (segment.match(/-/g) || []).length;
+
+  return segment.length < 20 && hyphenCount < 2;
+};
+
+/**
+ * Check if reader is applicable for current url
+ * Same as https://dxr.mozilla.org/mozilla-central/source/toolkit/components/reader/Readerable.js#60
+ */
+export const shouldRunOnUrl = (): boolean => {
+  const blockedHosts = [
+    'amazon.com',
+    'github.com',
+    'mail.google.com',
+    'pinterest.com',
+    'reddit.com',
+    'twitter.com',
+    'youtube.com',
+  ];
+
+  if (!['http:', 'https:'].includes(window.location.protocol)) {
+    return false;
+  }
+
+  if (window.location.pathname === '/') {
+    return false;
+  }
+
+  if (looksLikeSectionPath(window.location.pathname)) {
+    return false;
+  }
+
+  if (blockedHosts.some(blockedHost => document.domain.endsWith(blockedHost))) {
+    return false;
+  }
+
+  return true;
+};
+
+// MediaWiki (Wikipedia and other wikis) embeds this flag on every page —
+// true only for the wiki's designated portal/home page, e.g. Main_Page.
+// Depends on script content, so it needs the DOM parsed — unlike
+// shouldRunOnUrl()'s checks, which only need the URL. Checked once, not
+// retried like isProbablyAnArticle(): more waiting won't change the answer.
+export const isMediaWikiMainPage = (): boolean =>
+  [...document.scripts].some(script =>
+    /"wgIsMainPage"\s*:\s*true/.test(script.textContent ?? '')
+  );
+
+export const isProbablyAnArticle = (): boolean =>
+  isProbablyReaderable(document);
+
+export const isReaderable = (): boolean => {
+  // Once mounted, the original content is stripped and the article lives
+  // in a shadow root `querySelectorAll` can't see — short-circuit instead.
+  if (document.getElementById('stylebot-reader')) {
+    return true;
+  }
+
+  return shouldRunOnUrl() && !isMediaWikiMainPage() && isProbablyAnArticle();
+};

--- a/src/readability/heuristics.ts
+++ b/src/readability/heuristics.ts
@@ -49,11 +49,8 @@ export const shouldRunOnUrl = (): boolean => {
   return true;
 };
 
-// MediaWiki (Wikipedia and other wikis) embeds this flag on every page —
-// true only for the wiki's designated portal/home page, e.g. Main_Page.
-// Depends on script content, so it needs the DOM parsed — unlike
-// shouldRunOnUrl()'s checks, which only need the URL. Checked once, not
-// retried like isProbablyAnArticle(): more waiting won't change the answer.
+// MediaWiki embeds this flag on every page — true only for the wiki's
+// designated portal/home page, e.g. Main_Page.
 export const isMediaWikiMainPage = (): boolean =>
   [...document.scripts].some(script =>
     /"wgIsMainPage"\s*:\s*true/.test(script.textContent ?? '')

--- a/src/readability/heuristics.ts
+++ b/src/readability/heuristics.ts
@@ -56,9 +56,6 @@ export const isMediaWikiMainPage = (): boolean =>
     /"wgIsMainPage"\s*:\s*true/.test(script.textContent ?? '')
   );
 
-export const isProbablyAnArticle = (): boolean =>
-  isProbablyReaderable(document);
-
 export const isReaderable = (): boolean => {
   // Once mounted, the original content is stripped and the article lives
   // in a shadow root `querySelectorAll` can't see — short-circuit instead.
@@ -66,5 +63,7 @@ export const isReaderable = (): boolean => {
     return true;
   }
 
-  return shouldRunOnUrl() && !isMediaWikiMainPage() && isProbablyAnArticle();
+  return (
+    shouldRunOnUrl() && !isMediaWikiMainPage() && isProbablyReaderable(document)
+  );
 };

--- a/src/readability/index.scss
+++ b/src/readability/index.scss
@@ -9,17 +9,29 @@
 
   @import './scss/content.scss';
 
-  --main-background: #fff;
-  --main-foreground: #333;
+  --main-background: #faf8f3;
+  --main-foreground: #2b2926;
+  --muted-foreground: #6f6a5f;
+  --border-color: #e4ddcf;
+  --link-color: #0b6fb3;
+  --link-visited-color: #7c3fa8;
 
   &.sepia {
     --main-background: #f4ecd8;
     --main-foreground: #5b4636;
+    --muted-foreground: #8a7360;
+    --border-color: #e0cfab;
+    --link-color: #9c5c1f;
+    --link-visited-color: #7a4518;
   }
 
   &.dark {
-    --main-background: #222;
-    --main-foreground: #bababa;
+    --main-background: #201f1d;
+    --main-foreground: #cac5bc;
+    --muted-foreground: #96918a;
+    --border-color: #3c3a36;
+    --link-color: #6cb6ff;
+    --link-visited-color: #c792ea;
   }
 }
 
@@ -30,13 +42,24 @@
 
   color: var(--main-foreground);
   background-color: var(--main-background);
+  transition: background-color 0.2s ease, color 0.2s ease, opacity 0.25s ease;
 
   width: 100%;
   height: 100%;
   overflow: auto;
+
+  &.closing {
+    opacity: 0;
+  }
 }
 
 .stylebot-reader-body {
   margin: 0 auto;
   padding: var(--body-padding);
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+
+.stylebot-reader.revealed .stylebot-reader-body {
+  opacity: 1;
 }

--- a/src/readability/index.ts
+++ b/src/readability/index.ts
@@ -1,4 +1,5 @@
 import './index.scss';
 
 export { apply, remove } from './apply';
-export { isReaderable } from './utils';
+export { isReaderable } from './heuristics';
+export { previewReaderFont, onPreviewReaderFont } from './preview';

--- a/src/readability/index.ts
+++ b/src/readability/index.ts
@@ -3,3 +3,4 @@ import './index.scss';
 export { apply, remove } from './apply';
 export { isReaderable } from './heuristics';
 export { previewReaderFont, onPreviewReaderFont } from './preview';
+export { readabilityFonts } from './fonts';

--- a/src/readability/loader.ts
+++ b/src/readability/loader.ts
@@ -5,9 +5,9 @@ import { ReadabilityTheme } from '@stylebot/types';
 const THEME_CACHE_KEY = 'stylebot-reader-theme';
 
 const THEME_BACKGROUNDS: Record<ReadabilityTheme, string> = {
-  light: '#fff',
+  light: '#faf8f3',
   sepia: '#f4ecd8',
-  dark: '#222',
+  dark: '#201f1d',
 };
 
 export const cacheTheme = (theme: ReadabilityTheme): void => {

--- a/src/readability/preview.ts
+++ b/src/readability/preview.ts
@@ -1,0 +1,15 @@
+// Both live in the same content-script bundle on the same page, so a plain
+// DOM event is enough — no need for chrome.runtime messaging or storage.
+const PREVIEW_FONT_EVENT = 'stylebot-reader-preview-font';
+
+export const previewReaderFont = (font: string | null): void => {
+  window.dispatchEvent(new CustomEvent(PREVIEW_FONT_EVENT, { detail: font }));
+};
+
+export const onPreviewReaderFont = (
+  callback: (font: string | null) => void
+): void => {
+  window.addEventListener(PREVIEW_FONT_EVENT, event => {
+    callback((event as CustomEvent<string | null>).detail);
+  });
+};

--- a/src/readability/reader.ts
+++ b/src/readability/reader.ts
@@ -1,8 +1,8 @@
 import Vue from 'vue';
+import { isProbablyReaderable } from '@mozilla/readability';
 
 import App from './App.vue';
 import { getDomainUrlAndSource, getReadabilityArticle } from './utils';
-import { isProbablyAnArticle } from './heuristics';
 
 import { ReadabilityArticle } from '@stylebot/types';
 import { cacheDocument } from './cache';
@@ -64,7 +64,7 @@ const initVueApp = async (
 
 export const initReader = async (): Promise<void> => {
   return new Promise(async (resolve, reject) => {
-    if (!isProbablyAnArticle()) {
+    if (!isProbablyReaderable(document)) {
       reject();
       return;
     }

--- a/src/readability/reader.ts
+++ b/src/readability/reader.ts
@@ -1,9 +1,8 @@
 import Vue from 'vue';
 
-import { isProbablyReaderable } from '@mozilla/readability';
-
 import App from './App.vue';
 import { getDomainUrlAndSource, getReadabilityArticle } from './utils';
+import { isProbablyAnArticle } from './heuristics';
 
 import { ReadabilityArticle } from '@stylebot/types';
 import { cacheDocument } from './cache';
@@ -65,7 +64,7 @@ const initVueApp = async (
 
 export const initReader = async (): Promise<void> => {
   return new Promise(async (resolve, reject) => {
-    if (!isProbablyReaderable(document)) {
+    if (!isProbablyAnArticle()) {
       reject();
       return;
     }

--- a/src/readability/scss/content.scss
+++ b/src/readability/scss/content.scss
@@ -93,19 +93,27 @@
 
   p > img:only-child,
   p > a:only-child > img:only-child,
-  td > img:only-child,
-  td > a:only-child > img:only-child,
   .wp-caption img,
   figure img,
   img[moz-reader-center] {
     display: block;
     margin-inline: auto;
+  }
+
+  p > img:only-child,
+  p > a:only-child > img:only-child,
+  td[colspan] img,
+  .wp-caption img,
+  figure img,
+  img[moz-reader-center] {
     border-radius: 8px;
     box-shadow: 0 2px 8px color-mix(in srgb, var(--main-foreground) 20%, transparent);
   }
 
   .caption,
-  .wp-caption-text figcaption {
+  .wp-caption-text figcaption,
+  figcaption {
+    display: block;
     margin-top: 0.6em;
     text-align: center;
     font-size: 0.9em;
@@ -168,6 +176,16 @@
 
   th {
     background: color-mix(in srgb, var(--main-foreground) 6%, transparent);
+  }
+
+  // Infobox image rows span both columns via colspan — the image is often
+  // nested too deep for margin-auto, so center via the cell's text-align.
+  td[colspan] {
+    text-align: center;
+  }
+
+  td[colspan] img {
+    display: inline-block;
   }
 
   tr:last-child > td,

--- a/src/readability/scss/content.scss
+++ b/src/readability/scss/content.scss
@@ -93,17 +93,21 @@
 
   p > img:only-child,
   p > a:only-child > img:only-child,
+  td > img:only-child,
+  td > a:only-child > img:only-child,
   .wp-caption img,
-  figure img {
-    display: block;
-  }
-
+  figure img,
   img[moz-reader-center] {
+    display: block;
     margin-inline: auto;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px color-mix(in srgb, var(--main-foreground) 20%, transparent);
   }
 
   .caption,
   .wp-caption-text figcaption {
+    margin-top: 0.6em;
+    text-align: center;
     font-size: 0.9em;
     line-height: 1.48em;
     font-style: italic;

--- a/src/readability/scss/content.scss
+++ b/src/readability/scss/content.scss
@@ -122,6 +122,12 @@
     color: var(--muted-foreground);
   }
 
+  // Decorative credit/type icons (camera, play button, etc.) — the caption
+  // text already states this, and the icon loses its source page's spacing.
+  figcaption svg {
+    display: none;
+  }
+
   code,
   pre {
     white-space: pre-wrap;

--- a/src/readability/scss/content.scss
+++ b/src/readability/scss/content.scss
@@ -19,22 +19,33 @@
   h1,
   h2,
   h3 {
-    font-weight: bold;
+    font-weight: 700;
+    margin: 1.8em 0 0.6em;
+
+    &:first-child {
+      margin-top: 0;
+    }
   }
 
   h1 {
     font-size: 1.6em;
-    line-height: 1.25em;
+    line-height: 1.3em;
   }
 
   h2 {
-    font-size: 1.2em;
-    line-height: 1.51em;
+    font-size: 1.3em;
+    line-height: 1.45em;
   }
 
   h3 {
-    font-size: 1em;
-    line-height: 1.66em;
+    font-size: 1.1em;
+    line-height: 1.5em;
+  }
+
+  hr {
+    border: 0;
+    border-top: 1px solid var(--border-color);
+    margin: 2em 0;
   }
 
   a:link {
@@ -45,11 +56,11 @@
   a:link,
   a:link:hover,
   a:link:active {
-    color: #0095dd;
+    color: var(--link-color, #0095dd);
   }
 
   a:visited {
-    color: #c2e;
+    color: var(--link-visited-color, #c2e);
   }
 
   * {
@@ -96,16 +107,24 @@
     font-size: 0.9em;
     line-height: 1.48em;
     font-style: italic;
+    color: var(--muted-foreground);
   }
 
   code,
   pre {
     white-space: pre-wrap;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace;
+  }
+
+  pre {
+    background: color-mix(in srgb, var(--main-foreground) 6%, transparent);
   }
 
   blockquote {
     padding: 0;
     padding-inline-start: 16px;
+    border-inline-start: 3px solid var(--link-color);
+    color: var(--muted-foreground);
   }
 
   ul,
@@ -123,17 +142,38 @@
     list-style: decimal;
   }
 
-  table,
+  table {
+    width: 100% !important;
+    border-collapse: separate;
+    border-spacing: 0;
+    margin: 1.5em 0;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+
   th,
   td {
-    border: 1px solid currentColor;
-    border-collapse: collapse;
-    padding: 6px;
+    width: auto !important;
+    border: 0;
+    border-bottom: 1px solid var(--border-color);
+    border-inline-end: 1px solid var(--border-color);
+    padding: 8px 12px;
     vertical-align: top;
   }
 
-  table {
-    margin: 5px;
+  th {
+    background: color-mix(in srgb, var(--main-foreground) 6%, transparent);
+  }
+
+  tr:last-child > td,
+  tr:last-child > th {
+    border-bottom: 0;
+  }
+
+  tr > td:last-child,
+  tr > th:last-child {
+    border-inline-end: 0;
   }
 
   /* Visually hide (but don't display: none) screen reader elements */

--- a/src/readability/utils.ts
+++ b/src/readability/utils.ts
@@ -1,50 +1,10 @@
-import { Readability, isProbablyReaderable } from '@mozilla/readability';
+import { Readability } from '@mozilla/readability';
 
 import { ReadabilityArticle } from '@stylebot/types';
 
 export const getDomainUrlAndSource = (): { url: string; source: string } => {
   const parts = window.location.href.split('/');
   return { url: `${parts[0]}//${parts[2]}`, source: parts[2] };
-};
-
-/**
- * Check if reader is applicable for current url
- * Same as https://dxr.mozilla.org/mozilla-central/source/toolkit/components/reader/Readerable.js#60
- */
-export const shouldRunOnUrl = (): boolean => {
-  const blockedHosts = [
-    'amazon.com',
-    'github.com',
-    'mail.google.com',
-    'pinterest.com',
-    'reddit.com',
-    'twitter.com',
-    'youtube.com',
-  ];
-
-  if (!['http:', 'https:'].includes(window.location.protocol)) {
-    return false;
-  }
-
-  if (window.location.pathname === '/') {
-    return false;
-  }
-
-  if (blockedHosts.some(blockedHost => document.domain.endsWith(blockedHost))) {
-    return false;
-  }
-
-  return true;
-};
-
-export const isReaderable = (): boolean => {
-  // Once mounted, the original content is stripped and the article lives
-  // in a shadow root `querySelectorAll` can't see — short-circuit instead.
-  if (document.getElementById('stylebot-reader')) {
-    return true;
-  }
-
-  return shouldRunOnUrl() && isProbablyReaderable(document);
 };
 
 /**

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -1,6 +1,7 @@
 import {
   StylebotOptions,
   StylebotCommands,
+  StylebotFonts,
   ReadabilitySettings,
   StylebotEditorCommands,
 } from '@stylebot/types';
@@ -55,8 +56,17 @@ export const defaultEditorCommands: StylebotEditorCommands = {
 
 export const defaultReadabilitySettings: ReadabilitySettings = {
   size: 16,
-  width: 36,
+  width: 40,
   theme: 'light',
   lineHeight: 1.6,
-  font: 'Helvetica',
+  font: 'Merriweather',
 };
+
+// Kept apart from `defaultOptions.fonts`, which also powers the
+// general-purpose Text panel and needs display/code fonts too.
+export const readabilityFonts: StylebotFonts = [
+  'Merriweather',
+  'Georgia',
+  'Lora',
+  'Helvetica',
+];

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -1,7 +1,6 @@
 import {
   StylebotOptions,
   StylebotCommands,
-  StylebotFonts,
   ReadabilitySettings,
   StylebotEditorCommands,
 } from '@stylebot/types';
@@ -61,12 +60,3 @@ export const defaultReadabilitySettings: ReadabilitySettings = {
   lineHeight: 1.6,
   font: 'Merriweather',
 };
-
-// Kept apart from `defaultOptions.fonts`, which also powers the
-// general-purpose Text panel and needs display/code fonts too.
-export const readabilityFonts: StylebotFonts = [
-  'Merriweather',
-  'Georgia',
-  'Lora',
-  'Helvetica',
-];

--- a/src/types/BackgroundPageMessage.ts
+++ b/src/types/BackgroundPageMessage.ts
@@ -75,9 +75,8 @@ export type SetReadability = {
   value: boolean;
 };
 
-// Sent whenever the reader mounts or unmounts, so the background can
-// refresh the badge — carries no state itself; the background re-queries
-// GetIsReadabilityActive on the sender's tab for the live answer.
+// Sent when the reader mounts/unmounts — carries no state, the background
+// re-queries GetIsReadabilityActive on the sender's tab for the live answer.
 export type ReadabilityActiveChanged = {
   name: 'ReadabilityActiveChanged';
 };

--- a/src/types/BackgroundPageMessage.ts
+++ b/src/types/BackgroundPageMessage.ts
@@ -75,6 +75,13 @@ export type SetReadability = {
   value: boolean;
 };
 
+// Sent whenever the reader mounts or unmounts, so the background can
+// refresh the badge — carries no state itself; the background re-queries
+// GetIsReadabilityActive on the sender's tab for the live answer.
+export type ReadabilityActiveChanged = {
+  name: 'ReadabilityActiveChanged';
+};
+
 export type GetCommands = {
   name: 'GetCommands';
 };
@@ -116,6 +123,7 @@ type BackgroundPageMessage =
   | OpenOptionsPage
   | OpenDonatePage
   | SetReadability
+  | ReadabilityActiveChanged
   | GetCommands
   | SetCommands
   | GetReadabilitySettings

--- a/src/types/TabMessage.ts
+++ b/src/types/TabMessage.ts
@@ -34,6 +34,15 @@ export type GetIsPageReaderable = {
   name: 'GetIsPageReaderable';
 };
 
+// Whether the reader is actually mounted on this tab right now — distinct
+// from a style's stored readability preference, which can be true for a
+// whole domain while the current page doesn't actually qualify (e.g. a
+// listing page). Answered live from the DOM rather than tracked/persisted,
+// so there's no stale-state race to worry about.
+export type GetIsReadabilityActive = {
+  name: 'GetIsReadabilityActive';
+};
+
 export type UpdateReader = {
   name: 'UpdateReader';
   value: ReadabilitySettings;
@@ -48,6 +57,7 @@ type TabMessage =
   | TabUpdated
   | GetIsStylebotOpen
   | GetIsPageReaderable
+  | GetIsReadabilityActive
   | UpdateReader;
 
 export default TabMessage;

--- a/src/types/TabMessage.ts
+++ b/src/types/TabMessage.ts
@@ -34,11 +34,8 @@ export type GetIsPageReaderable = {
   name: 'GetIsPageReaderable';
 };
 
-// Whether the reader is actually mounted on this tab right now — distinct
-// from a style's stored readability preference, which can be true for a
-// whole domain while the current page doesn't actually qualify (e.g. a
-// listing page). Answered live from the DOM rather than tracked/persisted,
-// so there's no stale-state race to worry about.
+// Whether the reader is mounted on this tab right now, distinct from a
+// style's stored preference — answered live from the DOM, never persisted.
 export type GetIsReadabilityActive = {
   name: 'GetIsReadabilityActive';
 };


### PR DESCRIPTION
## Summary
- Refresh readability's visual theming: softer off-white/dark backgrounds, per-theme link colors, smoother theme transitions, and nicer table borders/width that use the full content area.
- Default the reader's width/font, and add a font hover-preview in the Magic editor panel.
- Fix a class of bugs where readability incorrectly ran (or the badge/UI reported the wrong status) on pages where it shouldn't: listing pages, a wiki's main page, and domain-wide bleed-through onto pages that don't actually qualify.
- Make the extension badge and editor UI (Magic mode auto-select, disabled Basic/Code panels, popup toggle) reflect the *live*, per-page readability state instead of a stored/stale flag.
- Dedupe the background badge-refresh logic into a shared `refreshBadgeForTab` helper.

## Test plan
- [x] `yarn lint`
- [x] `yarn jest`
- [x] `yarn tsc --noEmit` (no new errors; two pre-existing, unrelated errors remain in `dark-mode`/`migrate`)
- [x] Manually verified on Wikipedia and a few news sites: badge/toggle accuracy across article pages, listing pages, and a wiki's main page; theme switching; table rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)