### PR TITLE
style: polish reader content styling (round 1)

### DIFF
--- a/src/readability/scss/content.scss
+++ b/src/readability/scss/content.scss
@@ -93,19 +93,27 @@
 
   p > img:only-child,
   p > a:only-child > img:only-child,
-  td > img:only-child,
-  td > a:only-child > img:only-child,
   .wp-caption img,
   figure img,
   img[moz-reader-center] {
     display: block;
     margin-inline: auto;
+  }
+
+  p > img:only-child,
+  p > a:only-child > img:only-child,
+  td[colspan] img,
+  .wp-caption img,
+  figure img,
+  img[moz-reader-center] {
     border-radius: 8px;
     box-shadow: 0 2px 8px color-mix(in srgb, var(--main-foreground) 20%, transparent);
   }
 
   .caption,
-  .wp-caption-text figcaption {
+  .wp-caption-text figcaption,
+  figcaption {
+    display: block;
     margin-top: 0.6em;
     text-align: center;
     font-size: 0.9em;
@@ -168,6 +176,16 @@
 
   th {
     background: color-mix(in srgb, var(--main-foreground) 6%, transparent);
+  }
+
+  // Infobox image rows span both columns via colspan — the image is often
+  // nested too deep for margin-auto, so center via the cell's text-align.
+  td[colspan] {
+    text-align: center;
+  }
+
+  td[colspan] img {
+    display: inline-block;
   }
 
   tr:last-child > td,

--- a/src/readability/scss/content.scss
+++ b/src/readability/scss/content.scss
@@ -93,17 +93,21 @@
 
   p > img:only-child,
   p > a:only-child > img:only-child,
+  td > img:only-child,
+  td > a:only-child > img:only-child,
   .wp-caption img,
-  figure img {
-    display: block;
-  }
-
+  figure img,
   img[moz-reader-center] {
+    display: block;
     margin-inline: auto;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px color-mix(in srgb, var(--main-foreground) 20%, transparent);
   }
 
   .caption,
   .wp-caption-text figcaption {
+    margin-top: 0.6em;
+    text-align: center;
     font-size: 0.9em;
     line-height: 1.48em;
     font-style: italic;

--- a/src/readability/scss/content.scss
+++ b/src/readability/scss/content.scss
@@ -122,6 +122,12 @@
     color: var(--muted-foreground);
   }
 
+  // Decorative credit/type icons (camera, play button, etc.) — the caption
+  // text already states this, and the icon loses its source page's spacing.
+  figcaption svg {
+    display: none;
+  }
+
   code,
   pre {
     white-space: pre-wrap;


### PR DESCRIPTION
## Summary
- Polish readability theming
- Center and style standalone images in reader content
- Center infobox images and style plain figcaptions
- Hide decorative icons inside figcaption

Stacked on `readability/01-mode-badge-fixes`. Part of an incremental breakup
of `spike/defuddle-readability` — see the full PR chain (01 through 08).

## Test plan
- [ ] Open reader mode on an article with a standalone image and one with a
      Wikipedia-style infobox table image — confirm both center correctly
- [ ] Confirm figcaptions render without a stray decorative icon