### PR TITLE
refactor: migrate article extraction from Mozilla Readability to Defuddle

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "date-fns": "^2.16.1",
     "dedent": "^0.7.0",
     "deepmerge": "^4.2.2",
+    "defuddle": "^0.19.3",
     "ejs": "^3.1.3",
     "eslint": "^7.4.0",
     "eslint-config-prettier": "^6.11.0",

--- a/src/inject-css/apply-state.ts
+++ b/src/inject-css/apply-state.ts
@@ -11,6 +11,15 @@ import { CachedState } from './cache';
 let appliedUrls = new Set<string>();
 
 export const applyState = (state: CachedState): Promise<void> => {
+  // Called synchronously, ahead of CSS injection below — readability's own
+  // showLoader() needs to hide the page before the browser's first paint,
+  // and waiting on style injection (which may fetch @imports) risks missing it.
+  if (state.readability) {
+    applyReadability();
+  } else {
+    removeReadability();
+  }
+
   const enabled = state.styles.filter(style => style.enabled);
   const nextUrls = new Set(enabled.map(style => style.url));
 
@@ -26,11 +35,5 @@ export const applyState = (state: CachedState): Promise<void> => {
 
   return Promise.all(injections).then(() => {
     appliedUrls = nextUrls;
-
-    if (state.readability) {
-      applyReadability();
-    } else {
-      removeReadability();
-    }
   });
 };

--- a/src/inject-css/index.ts
+++ b/src/inject-css/index.ts
@@ -4,7 +4,10 @@
  * the page (hide-page.ts) until chrome.storage.local.get resolves.
  */
 import { extractImports, pruneImportCache } from '@stylebot/css';
-import { isReaderable } from '@stylebot/readability';
+// Bypasses the @stylebot/readability barrel, whose side-effectful SCSS
+// import defeats tree-shaking and would pull the whole apply/reader/Defuddle
+// stack into this document_start bundle just for this one heuristic.
+import { isReaderable } from '../readability/heuristics';
 import { getStylesForPage } from '@stylebot/styles';
 import { StyleMap, TabMessage } from '@stylebot/types';
 

--- a/src/readability/components/TheReader.vue
+++ b/src/readability/components/TheReader.vue
@@ -10,6 +10,7 @@
         :source="source"
         :title="article.title"
         :byline="article.byline"
+        :published="article.published"
       />
 
       <!-- eslint-disable vue/no-v-html - html is generated with the readability project -->

--- a/src/readability/components/TheReaderHeader.vue
+++ b/src/readability/components/TheReaderHeader.vue
@@ -5,7 +5,10 @@
     </a>
 
     <h1>{{ title }}</h1>
-    <div class="stylebot-reader-byline">{{ byline }}</div>
+    <div class="stylebot-reader-byline">
+      <span v-if="byline">{{ byline }}</span>
+      <span v-if="formattedDate" class="stylebot-reader-date">{{ formattedDate }}</span>
+    </div>
   </div>
 </template>
 
@@ -27,6 +30,12 @@ export default Vue.extend({
       default: '',
     },
 
+    published: {
+      type: String,
+      required: false,
+      default: '',
+    },
+
     url: {
       type: String,
       required: true,
@@ -35,6 +44,26 @@ export default Vue.extend({
     source: {
       type: String,
       required: true,
+    },
+  },
+
+  computed: {
+    formattedDate(): string {
+      if (!this.published) {
+        return '';
+      }
+
+      const date = new Date(this.published);
+
+      if (Number.isNaN(date.getTime())) {
+        return '';
+      }
+
+      return date.toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      });
     },
   },
 });
@@ -72,9 +101,18 @@ export default Vue.extend({
 }
 
 .stylebot-reader-byline {
-  font-size: 1em;
+  font-size: 0.85em;
   font-weight: 300;
   color: var(--muted-foreground);
   margin-bottom: 30px;
+
+  > span:not(:first-child)::before {
+    content: '·';
+    margin: 0 6px;
+  }
+}
+
+.stylebot-reader-date {
+  opacity: 0.7;
 }
 </style>

--- a/src/readability/utils.ts
+++ b/src/readability/utils.ts
@@ -7,12 +7,53 @@ export const getDomainUrlAndSource = (): { url: string; source: string } => {
   return { url: `${parts[0]}//${parts[2]}`, source: parts[2] };
 };
 
+// Sites often serve the same photo under multiple resized-variant URLs (a
+// different filename suffix, e.g. NYT's "-facebookJumbo" vs
+// "-mobileMasterAt3x", or a different resize query param) — comparing raw
+// URLs misses these, so compare directory + filename-prefix instead.
+const imageIdentity = (url: string): { directory: string; stem: string } => {
+  const withoutQuery = url.split('?')[0];
+  const lastSlash = withoutQuery.lastIndexOf('/');
+
+  return {
+    directory: withoutQuery.slice(0, lastSlash),
+    stem: withoutQuery.slice(lastSlash + 1).replace(/\.[a-z0-9]+$/i, '').toLowerCase(),
+  };
+};
+
+// A shared directory alone isn't enough — WordPress groups a whole month's
+// unrelated uploads under one directory — so also require the filenames to
+// share a meaningful prefix (the part before a size/variant suffix).
+const isSameImage = (a: string, b: string): boolean => {
+  const idA = imageIdentity(a);
+  const idB = imageIdentity(b);
+
+  if (idA.directory !== idB.directory) {
+    return false;
+  }
+
+  let sharedPrefixLength = 0;
+  while (idA.stem[sharedPrefixLength] === idB.stem[sharedPrefixLength]) {
+    sharedPrefixLength++;
+  }
+
+  return sharedPrefixLength >= Math.min(idA.stem.length, idB.stem.length) * 0.5;
+};
+
 // WordPress (and others) often render the hero image as a sibling of the
 // content container Defuddle scopes to, so it's resolved in metadata but
 // missing from `content` — build the tag via the DOM so the URL is safely
 // escaped, rather than interpolating it into an HTML string.
 const withLeadImage = (content: string, imageUrl?: string): string => {
-  if (!imageUrl || !/^https?:\/\//.test(imageUrl) || content.includes(imageUrl)) {
+  if (!imageUrl || !/^https?:\/\//.test(imageUrl)) {
+    return content;
+  }
+
+  const existingSrcs = [...content.matchAll(/<img[^>]*\ssrc="([^"]*)"/g)].map(
+    match => match[1]
+  );
+
+  if (existingSrcs.some(src => isSameImage(src, imageUrl))) {
     return content;
   }
 
@@ -24,6 +65,29 @@ const withLeadImage = (content: string, imageUrl?: string): string => {
   return `${figure.outerHTML}${content}`;
 };
 
+const normalizeText = (text: string): string => text.replace(/\s+/g, ' ').trim();
+
+// Defuddle's own "hero header block" cleanup treats a title+time+dek wrapper
+// as empty metadata chrome and deletes it whenever the dek reads as under 30
+// words of "prose" — dropping real subheadline text along with it. Its
+// article.description metadata survives that removal, so recover it here.
+const withDescription = (content: string, description?: string): string => {
+  if (!description) {
+    return content;
+  }
+
+  const plainContent = normalizeText(content.replace(/<[^>]+>/g, ' '));
+
+  if (plainContent.includes(normalizeText(description))) {
+    return content;
+  }
+
+  const p = document.createElement('p');
+  p.textContent = description;
+
+  return `${p.outerHTML}${content}`;
+};
+
 /**
  * Parse a clone of the live document — Defuddle mutates whatever it's
  * given (strips scripts/styles etc.), so the original document must stay
@@ -32,18 +96,26 @@ const withLeadImage = (content: string, imageUrl?: string): string => {
 export const getReadabilityArticle = async (): Promise<ReadabilityArticle> => {
   const doc = document.cloneNode(true) as Document;
 
-  // The clone has no defaultView, so Defuddle's small-image filter can't read
-  // rendered size and falls back to (often-wrong) static width/height attrs.
-  const article = new Defuddle(doc, { removeSmallImages: false }).parse();
+  const article = new Defuddle(doc, {
+    // The clone has no defaultView, so Defuddle's small-image filter can't
+    // read rendered size and falls back to (often-wrong) width/height attrs.
+    removeSmallImages: false,
+  }).parse();
 
   if (!article || !article.content) {
     throw new Error('Defuddle failed to parse the page');
   }
 
+  const content = withDescription(
+    withLeadImage(article.content, article.image),
+    article.description
+  );
+
   return {
     title: article.title ?? '',
     byline: article.author ?? '',
-    content: withLeadImage(article.content, article.image),
+    content,
     siteName: article.site ?? '',
+    published: article.published ?? '',
   };
 };

--- a/src/readability/utils.ts
+++ b/src/readability/utils.ts
@@ -1,4 +1,4 @@
-import { Readability } from '@mozilla/readability';
+import Defuddle from 'defuddle';
 
 import { ReadabilityArticle } from '@stylebot/types';
 
@@ -8,22 +8,22 @@ export const getDomainUrlAndSource = (): { url: string; source: string } => {
 };
 
 /**
- * Parse a clone of the live document — Readability mutates whatever it's
+ * Parse a clone of the live document — Defuddle mutates whatever it's
  * given (strips scripts/styles etc.), so the original document must stay
  * intact until reader mode is confirmed to apply.
  */
 export const getReadabilityArticle = async (): Promise<ReadabilityArticle> => {
   const doc = document.cloneNode(true) as Document;
-  const article = new Readability(doc).parse();
+  const article = new Defuddle(doc).parse();
 
   if (!article || !article.content) {
-    throw new Error('Readability failed to parse the page');
+    throw new Error('Defuddle failed to parse the page');
   }
 
   return {
     title: article.title ?? '',
-    byline: article.byline ?? '',
+    byline: article.author ?? '',
     content: article.content,
-    siteName: article.siteName ?? '',
+    siteName: article.site ?? '',
   };
 };

--- a/src/readability/utils.ts
+++ b/src/readability/utils.ts
@@ -7,6 +7,23 @@ export const getDomainUrlAndSource = (): { url: string; source: string } => {
   return { url: `${parts[0]}//${parts[2]}`, source: parts[2] };
 };
 
+// WordPress (and others) often render the hero image as a sibling of the
+// content container Defuddle scopes to, so it's resolved in metadata but
+// missing from `content` — build the tag via the DOM so the URL is safely
+// escaped, rather than interpolating it into an HTML string.
+const withLeadImage = (content: string, imageUrl?: string): string => {
+  if (!imageUrl || !/^https?:\/\//.test(imageUrl) || content.includes(imageUrl)) {
+    return content;
+  }
+
+  const figure = document.createElement('figure');
+  const img = document.createElement('img');
+  img.src = imageUrl;
+  figure.appendChild(img);
+
+  return `${figure.outerHTML}${content}`;
+};
+
 /**
  * Parse a clone of the live document — Defuddle mutates whatever it's
  * given (strips scripts/styles etc.), so the original document must stay
@@ -26,7 +43,7 @@ export const getReadabilityArticle = async (): Promise<ReadabilityArticle> => {
   return {
     title: article.title ?? '',
     byline: article.author ?? '',
-    content: article.content,
+    content: withLeadImage(article.content, article.image),
     siteName: article.site ?? '',
   };
 };

--- a/src/readability/utils.ts
+++ b/src/readability/utils.ts
@@ -14,7 +14,10 @@ export const getDomainUrlAndSource = (): { url: string; source: string } => {
  */
 export const getReadabilityArticle = async (): Promise<ReadabilityArticle> => {
   const doc = document.cloneNode(true) as Document;
-  const article = new Defuddle(doc).parse();
+
+  // The clone has no defaultView, so Defuddle's small-image filter can't read
+  // rendered size and falls back to (often-wrong) static width/height attrs.
+  const article = new Defuddle(doc, { removeSmallImages: false }).parse();
 
   if (!article || !article.content) {
     throw new Error('Defuddle failed to parse the page');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -60,6 +60,7 @@ export type ReadabilityArticle = {
   byline: string;
   content: string;
   siteName: string;
+  published: string;
 };
 
 export type ReadabilityTheme = 'light' | 'dark' | 'sepia';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1102,6 +1102,11 @@
   dependencies:
     extend "3.0.2"
 
+"@mixmark-io/domino@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@mixmark-io/domino/-/domino-2.2.0.tgz#4e8ec69bf1afeb7a14f0628b7e2c0f35bdb336c3"
+  integrity sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==
+
 "@mozilla/readability@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@mozilla/readability/-/readability-0.6.0.tgz#134e3ce3ff1676716e550de0b8de957bcc59208b"
@@ -1610,6 +1615,11 @@
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
+
+"@xmldom/xmldom@^0.9.10":
+  version "0.9.12"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.9.12.tgz#1f84c07cb95ccf28202299f77b5fd7fc257151e8"
+  integrity sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -2331,6 +2341,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
+boolbase@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-2.0.0.tgz#832968d211d5c008d833b86e049bb3943036e5b1"
+  integrity sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==
 
 bootstrap-vue@^2.15.0:
   version "2.21.1"
@@ -3063,6 +3078,11 @@ commander@2.9.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+commander@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
+  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
+
 commander@^2.19.0, commander@^2.20.0, commander@^2.3.0, commander@^2.6.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -3425,6 +3445,17 @@ css-select@^2.0.0:
     domutils "^1.7.0"
     nth-check "^1.0.2"
 
+css-select@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-7.0.0.tgz#7532bab5977b1f0e83bc16036661dbe0968b4dec"
+  integrity sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==
+  dependencies:
+    boolbase "^2.0.0"
+    css-what "^8.0.0"
+    domhandler "^6.0.1"
+    domutils "^4.0.2"
+    nth-check "^3.0.1"
+
 css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
@@ -3460,6 +3491,11 @@ css-what@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.3.0.tgz#10fec696a9ece2e591ac772d759aacabac38cd39"
   integrity sha512-pv9JPyatiPaQ6pf4OvD/dbfm0o5LviWmwxNWzblYf/1u9QZd0ihV+PMwy5jdQWQ3349kZmKEx9WXuSka2dM4cg==
+
+css-what@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-8.0.0.tgz#237889d60c4afef4736892f39e133ab4c8c21f0c"
+  integrity sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==
 
 css@^2.1.0:
   version "2.2.4"
@@ -3555,6 +3591,11 @@ cssom@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.4.4.tgz#5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10"
   integrity sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==
+
+cssom@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.5.0.tgz#d254fa92cd8b6fbd83811b9fbaed34663cc17c36"
+  integrity sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==
 
 cssom@~0.3.6:
   version "0.3.8"
@@ -3747,6 +3788,18 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
+defuddle@^0.19.3:
+  version "0.19.3"
+  resolved "https://registry.yarnpkg.com/defuddle/-/defuddle-0.19.3.tgz#ca7c71b1eaeab8a47ff702bb6ed18b19a3fdd05b"
+  integrity sha512-5ZbOQ/B+iiRRqSQWwmCx/zEuqZOA/5q7gxyE2/4O2Bxq7nUC0PgKw9EdyxqWbFF1nrrrYemSeR25jg4TmA2fsA==
+  dependencies:
+    commander "^12.1.0"
+  optionalDependencies:
+    linkedom "^0.18.12"
+    mathml-to-latex "^1.8.0"
+    temml "^0.13.3"
+    turndown "^7.2.0"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -3834,6 +3887,24 @@ dom-serializer@0:
     domelementtype "^2.0.1"
     entities "^2.0.0"
 
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
+dom-serializer@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-3.1.1.tgz#54be70ee4fcc2da010f488165e62294798dc57d3"
+  integrity sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==
+  dependencies:
+    domelementtype "^3.0.0"
+    domhandler "^6.0.0"
+    entities "^8.0.0"
+
 dom-serializer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
@@ -3857,6 +3928,16 @@ domelementtype@^2.0.1:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
   integrity sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==
 
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domelementtype@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-3.0.0.tgz#e6c0a24bd39ca5eb7ea67a98d2f699497d7bcc55"
+  integrity sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==
+
 domexception@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-2.0.1.tgz#fb44aefba793e1574b0af6aed2801d057529f304"
@@ -3870,6 +3951,20 @@ domhandler@^2.3.0:
   integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
   dependencies:
     domelementtype "1"
+
+domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
+domhandler@^6.0.0, domhandler@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-6.0.1.tgz#75f351a03a6e10c35e08418f9cf0d287e00797cf"
+  integrity sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==
+  dependencies:
+    domelementtype "^3.0.0"
 
 dompurify@3.4.8:
   version "3.4.8"
@@ -3893,6 +3988,24 @@ domutils@^1.5.1, domutils@^1.7.0:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+domutils@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.2.2.tgz#edbfe2b668b0c1d97c24baf0f1062b132221bc78"
+  integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+
+domutils@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-4.0.2.tgz#0c1ac1fdbe8f554a60a6f5eb143ee85630327c94"
+  integrity sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==
+  dependencies:
+    dom-serializer "^3.0.0"
+    domelementtype "^3.0.0"
+    domhandler "^6.0.0"
 
 dot-prop@^5.2.0:
   version "5.2.0"
@@ -4020,6 +4133,21 @@ entities@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
   integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
+
+entities@^4.2.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+entities@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-7.0.1.tgz#26e8a88889db63417dcb9a1e79a3f1bc92b5976b"
+  integrity sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==
+
+entities@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-8.0.0.tgz#c1df5fe3602429747fa233d0dd26f142f0ce4743"
+  integrity sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==
 
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
@@ -5320,6 +5448,21 @@ html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+html-escaper@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-3.0.3.tgz#4d336674652beb1dcbc29ef6b6ba7f6be6fdfed6"
+  integrity sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==
+
+htmlparser2@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-10.1.0.tgz#fe3f2e12c73b6e462d4e10395db9c1119e4d6ae4"
+  integrity sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.2.2"
+    entities "^7.0.1"
 
 htmlparser2@^3.9.1:
   version "3.10.1"
@@ -6703,6 +6846,17 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
+linkedom@^0.18.12:
+  version "0.18.13"
+  resolved "https://registry.yarnpkg.com/linkedom/-/linkedom-0.18.13.tgz#db4582d42d5606961dd8e596fc273bd8c06f50df"
+  integrity sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw==
+  dependencies:
+    css-select "^7.0.0"
+    cssom "^0.5.0"
+    html-escaper "^3.0.3"
+    htmlparser2 "^10.1.0"
+    uhyphen "^0.2.0"
+
 lint-staged@^10.5.4:
   version "10.5.4"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.5.4.tgz#cd153b5f0987d2371fc1d2847a409a2fe705b665"
@@ -6996,6 +7150,13 @@ marky@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/marky/-/marky-1.2.1.tgz#a3fcf82ffd357756b8b8affec9fdbf3a30dc1b02"
   integrity sha512-md9k+Gxa3qLH6sUKpeC2CNkJK/Ld+bEz5X96nYwloqphQE0CKCVEKco/6jxEZixinqNdz5RFi/KaCyfbMDMAXQ==
+
+mathml-to-latex@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/mathml-to-latex/-/mathml-to-latex-1.8.0.tgz#1007f1cb3f6c47453d5c52dbbcb90a823380c6be"
+  integrity sha512-gQ0uK3zqB8HwlfaXJkEL5rgaZNbKUiBMmBP/B/W+b+t6KcseLSuYb1b0BjLgS9ZiQa24ePkqTX8/6FaQuDL7wQ==
+  dependencies:
+    "@xmldom/xmldom" "^0.9.10"
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -7516,6 +7677,13 @@ nth-check@^1.0.2, nth-check@~1.0.1:
   integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
   dependencies:
     boolbase "~1.0.0"
+
+nth-check@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-3.0.1.tgz#a5ede96060f7f0b74d7d3d8425f2a8f0610c5776"
+  integrity sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==
+  dependencies:
+    boolbase "^2.0.0"
 
 nwsapi@^2.2.0:
   version "2.2.0"
@@ -9894,6 +10062,11 @@ tar@^6.0.2:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
+temml@^0.13.3:
+  version "0.13.5"
+  resolved "https://registry.yarnpkg.com/temml/-/temml-0.13.5.tgz#96c53c4ece59ae719859e2a5074b6d4251cee423"
+  integrity sha512-aPkDDgunanpLNL0ql32HbolqLep+w8DRcVXRql7rWrMt/PhczdLgL4UBYYVU3BYjCNjkGq4EqwIicu/zWr1iOg==
+
 term-size@^2.1.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.1.tgz#2a6a54840432c2fb6320fea0f415531e90189f54"
@@ -10175,6 +10348,13 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+turndown@^7.2.0:
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/turndown/-/turndown-7.2.4.tgz#42d98202aefa8c188c997b586bc6da78bdf27ea2"
+  integrity sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==
+  dependencies:
+    "@mixmark-io/domino" "^2.2.0"
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
@@ -10240,6 +10420,11 @@ typescript@^3.9.7:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+
+uhyphen@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/uhyphen/-/uhyphen-0.2.0.tgz#8fdf0623314486e020a3c00ee5cc7a12fe722b81"
+  integrity sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
## Summary
Switches the reader's article extraction engine from Mozilla Readability to
Defuddle, plus the stabilization work needed to make the switch behave
correctly:
- Disable Defuddle's small-image removal (re-enabled correctly in PR 05)
- Recover the hero image Defuddle drops from content
- Harden image dedup and recover the dropped dek/summary
- Show the article's published date in the reader header
- Apply readability synchronously, ahead of CSS injection

Stacked on `readability/02-content-styling-1`. Part of an incremental
breakup of `spike/defuddle-readability` — see the full PR chain (01 through 08).

## Test plan
- [ ] Open reader mode on a handful of varied article sites (news site,
      blog, Wikipedia) and confirm extraction quality (title, byline, hero
      image, body content, published date) looks correct
- [ ] Confirm no regression in how quickly the reader appears after toggling