### PR TITLE
feat: add animated loading experience for the reader

### DIFF
--- a/src/readability/apply.ts
+++ b/src/readability/apply.ts
@@ -1,5 +1,9 @@
 import { initReader } from './reader';
-import { shouldRunOnUrl, isMediaWikiMainPage } from './heuristics';
+import {
+  shouldRunOnUrl,
+  isMediaWikiMainPage,
+  shouldWaitForFullLoad,
+} from './heuristics';
 import { showLoader, hideLoader } from './loader';
 import { cacheUrl, didUrlChange, revertToCachedDocument } from './cache';
 
@@ -85,6 +89,44 @@ export const apply = async (forceApply = false): Promise<void> => {
   const myGeneration = generation;
 
   showLoader();
+
+  scheduleStart(myGeneration);
+};
+
+// Ceiling on the deferred-parse wait: if a stray resource never resolves,
+// parse anyway rather than leaving the themed loader up indefinitely.
+const FULL_LOAD_TIMEOUT_MS = 5000;
+
+const scheduleStart = (myGeneration: number): void => {
+  // Sites that populate their article images lazily (see shouldWaitForFullLoad)
+  // hand Defuddle placeholder srcs at DOMContentLoaded — wait for the window
+  // `load` event, by which the images have resolved, before parsing.
+  if (shouldWaitForFullLoad()) {
+    if (document.readyState === 'complete') {
+      startIfEligible(myGeneration);
+      return;
+    }
+
+    let started = false;
+    const start = (): void => {
+      if (started) {
+        return;
+      }
+      started = true;
+      startIfEligible(myGeneration);
+    };
+
+    const timeout = setTimeout(start, FULL_LOAD_TIMEOUT_MS);
+    window.addEventListener(
+      'load',
+      () => {
+        clearTimeout(timeout);
+        start();
+      },
+      { once: true }
+    );
+    return;
+  }
 
   // DOMContentLoaded only fires once, on the loading -> interactive
   // transition — attaching this listener after that point (e.g. toggled

--- a/src/readability/heuristics.ts
+++ b/src/readability/heuristics.ts
@@ -49,6 +49,16 @@ export const shouldRunOnUrl = (): boolean => {
   return true;
 };
 
+// Sites that attach or populate their article images lazily, after the initial
+// DOM is parsed (e.g. NYTimes swaps in real srcs post-load) — Defuddle run at
+// DOMContentLoaded captures placeholder/missing srcs. For these, defer the
+// parse to the window `load` event, by which the above-the-fold images have
+// resolved their real srcs.
+const DEFERRED_IMAGE_HOSTS = ['nytimes.com'];
+
+export const shouldWaitForFullLoad = (): boolean =>
+  DEFERRED_IMAGE_HOSTS.some(host => document.domain.endsWith(host));
+
 // MediaWiki embeds this flag on every page — true only for the wiki's
 // designated portal/home page, e.g. Main_Page.
 export const isMediaWikiMainPage = (): boolean =>

--- a/src/readability/loader-styles.ts
+++ b/src/readability/loader-styles.ts
@@ -1,0 +1,67 @@
+// Styles for the reader loading screen. Kept as a string builder (not a real
+// .css file) so it can be injected synchronously at document_start — the themed
+// background must paint before the browser's first frame, which rules out
+// fetching an extracted stylesheet at runtime.
+
+// Jade/teal ink accent for the "title" line — stands apart from the warm paper
+// themes. Swap this one constant to retint the animation.
+const ACCENT = '#2f9e8f';
+
+export const LOADER_ART_ID = 'stylebot-reader-loading-art';
+
+export type LoaderColors = {
+  background: string;
+  foreground: string;
+};
+
+/**
+ * Build the loading-screen CSS for the given theme colors. `lineCount` drives
+ * the staggered per-line animation delays so the "written lines" ripple stays
+ * in sync with however many skeleton lines the DOM renders.
+ */
+export const loaderCss = (
+  { background, foreground }: LoaderColors,
+  lineCount: number
+): string => {
+  // Stagger the ripple: title first, then each paragraph line after it.
+  const lineDelays = Array.from(
+    { length: lineCount },
+    (_, i) =>
+      `#${LOADER_ART_ID} > i:nth-child(${i + 1}) { animation-delay: ${i * 0.14}s; }`
+  ).join(' ');
+
+  return (
+    // Also paint body: the page's own <body> parses after document_start and
+    // may carry an opaque (often white) background that would otherwise paint
+    // over the themed html background before the reader mounts.
+    `html, body { background: ${background} !important; } ` +
+    'body { border: 0 !important; box-shadow: none !important; } ' +
+    'body *:not(#stylebot) { display: none; }' +
+    // The loader art lives directly under <html> (outside body), so it's
+    // unaffected by the body-child hide rule above.
+    `#${LOADER_ART_ID} {` +
+    '  position: fixed; inset: 0; margin: auto;' +
+    '  width: 130px; height: -moz-fit-content; height: fit-content;' +
+    '  display: flex; flex-direction: column; gap: 8px;' +
+    '  z-index: 2147483647; pointer-events: none; opacity: 0;' +
+    // Only fade the whole skeleton in after a delay — a reader that mounts
+    // quickly removes the loader first, so fast loads show nothing and only
+    // real waits (e.g. deferred lazy-image hosts) reveal the animation.
+    '  animation: stylebot-reader-fade-in 0.25s ease-out 0.6s forwards;' +
+    '}' +
+    `#${LOADER_ART_ID} > i {` +
+    '  display: block; height: 7px; border-radius: 3px;' +
+    `  background: ${foreground}; opacity: 0.45;` +
+    // Each line grows from the left ("written") then clears, staggered per line
+    // below, so the article appears to be laid out into clean lines.
+    '  transform: scaleX(0); transform-origin: left center;' +
+    '  animation: stylebot-reader-write 1.8s ease-in-out infinite;' +
+    '}' +
+    `#${LOADER_ART_ID} > i.title {` +
+    `  height: 9px; background: ${ACCENT}; opacity: 0.9; margin-bottom: 4px;` +
+    '}' +
+    lineDelays +
+    '@keyframes stylebot-reader-write { 0%,100% { transform: scaleX(0); } 30%,70% { transform: scaleX(1); } }' +
+    '@keyframes stylebot-reader-fade-in { to { opacity: 1; } }'
+  );
+};

--- a/src/readability/loader.ts
+++ b/src/readability/loader.ts
@@ -1,5 +1,7 @@
 import { ReadabilityTheme } from '@stylebot/types';
 
+import { loaderCss, LOADER_ART_ID } from './loader-styles';
+
 // Read synchronously so the loading screen can match the reader's theme
 // immediately, instead of flashing white until settings are fetched.
 const THEME_CACHE_KEY = 'stylebot-reader-theme';
@@ -9,6 +11,24 @@ const THEME_BACKGROUNDS: Record<ReadabilityTheme, string> = {
   sepia: '#f4ecd8',
   dark: '#201f1d',
 };
+
+// Muted foreground per theme (matches the reader's own body text tones) —
+// used for the faint skeleton lines so they read against the themed background.
+const THEME_FOREGROUNDS: Record<ReadabilityTheme, string> = {
+  light: '#2b2926',
+  sepia: '#5b4636',
+  dark: '#cac5bc',
+};
+
+// Skeleton article: an accent title line over paragraph lines of varied width
+// (the last one short, like a paragraph's final line). Widths in %.
+const LOADER_LINES: Array<{ width: number; title?: boolean }> = [
+  { width: 40, title: true },
+  { width: 100 },
+  { width: 96 },
+  { width: 99 },
+  { width: 82 },
+];
 
 export const cacheTheme = (theme: ReadabilityTheme): void => {
   try {
@@ -25,7 +45,6 @@ export const cacheTheme = (theme: ReadabilityTheme): void => {
  * or a white screen appears for a prolonged period, especially for slower websites.
  */
 export const showLoader = (): void => {
-  const style = document.createElement('style');
   let cachedTheme: ReadabilityTheme | null = null;
 
   try {
@@ -35,6 +54,7 @@ export const showLoader = (): void => {
   }
 
   const background = (cachedTheme && THEME_BACKGROUNDS[cachedTheme]) || THEME_BACKGROUNDS.light;
+  const foreground = (cachedTheme && THEME_FOREGROUNDS[cachedTheme]) || THEME_FOREGROUNDS.light;
 
   // Paint the themed background inline on documentElement, synchronously and
   // ahead of any stylesheet parse. An injected <style> only takes effect after
@@ -43,24 +63,30 @@ export const showLoader = (): void => {
   // white canvas.
   document.documentElement.style.setProperty('background', background, 'important');
 
+  const style = document.createElement('style');
   style.type = 'text/css';
   style.setAttribute('id', 'stylebot-reader-loading');
   style.appendChild(
-    document.createTextNode(
-      // Also paint body: the page's own <body> parses after document_start and
-      // may carry an opaque (often white) background that would otherwise paint
-      // over the themed html background before the reader mounts.
-      `html, body { background: ${background} !important; } ` +
-        'body { border: 0 !important; box-shadow: none !important; } ' +
-        'body *:not(#stylebot) { display: none; }'
-    )
+    document.createTextNode(loaderCss({ background, foreground }, LOADER_LINES.length))
   );
-
   document.documentElement.appendChild(style);
+
+  const art = document.createElement('div');
+  art.setAttribute('id', LOADER_ART_ID);
+  LOADER_LINES.forEach(({ width, title }) => {
+    const line = document.createElement('i');
+    if (title) {
+      line.className = 'title';
+    }
+    line.style.width = `${width}%`;
+    art.appendChild(line);
+  });
+  document.documentElement.appendChild(art);
 };
 
 export const hideLoader = (): void => {
   document.getElementById('stylebot-reader-loading')?.remove();
+  document.getElementById(LOADER_ART_ID)?.remove();
   // Drop the inline background set in showLoader so the original page (on
   // revert) isn't left with the loader's theme color painted over it.
   document.documentElement.style.removeProperty('background');

--- a/src/readability/loader.ts
+++ b/src/readability/loader.ts
@@ -36,11 +36,21 @@ export const showLoader = (): void => {
 
   const background = (cachedTheme && THEME_BACKGROUNDS[cachedTheme]) || THEME_BACKGROUNDS.light;
 
+  // Paint the themed background inline on documentElement, synchronously and
+  // ahead of any stylesheet parse. An injected <style> only takes effect after
+  // a CSSOM parse + style recalc; an inline root style commits immediately, so
+  // the browser has the theme color for its first paint rather than the default
+  // white canvas.
+  document.documentElement.style.setProperty('background', background, 'important');
+
   style.type = 'text/css';
   style.setAttribute('id', 'stylebot-reader-loading');
   style.appendChild(
     document.createTextNode(
-      `html { background: ${background} !important; } ` +
+      // Also paint body: the page's own <body> parses after document_start and
+      // may carry an opaque (often white) background that would otherwise paint
+      // over the themed html background before the reader mounts.
+      `html, body { background: ${background} !important; } ` +
         'body { border: 0 !important; box-shadow: none !important; } ' +
         'body *:not(#stylebot) { display: none; }'
     )
@@ -51,4 +61,7 @@ export const showLoader = (): void => {
 
 export const hideLoader = (): void => {
   document.getElementById('stylebot-reader-loading')?.remove();
+  // Drop the inline background set in showLoader so the original page (on
+  // revert) isn't left with the loader's theme color painted over it.
+  document.documentElement.style.removeProperty('background');
 };


### PR DESCRIPTION
## Summary
- Eliminate readability load white flash by painting body, not just html
- Defer Defuddle to window load on lazy-image hosts (NYTimes)
- Show an animated "article distilling" loader during the reader wait

Stacked on `readability/03-defuddle-migration`. Part of an incremental
breakup of `spike/defuddle-readability` — see the full PR chain (01 through 08).

## Test plan
- [ ] Toggle readability on a slow-loading page and confirm no white flash
      before the themed background paints
- [ ] Toggle readability on a NYTimes article and confirm images load
      correctly (previously affected by lazy-loading)
- [ ] Confirm the loading animation appears during the wait and disappears
      once the reader is ready