### PR TITLE
style: polish reader content styling (round 2)

### DIFF
--- a/src/readability/apply.ts
+++ b/src/readability/apply.ts
@@ -98,9 +98,7 @@ export const apply = async (forceApply = false): Promise<void> => {
 const FULL_LOAD_TIMEOUT_MS = 5000;
 
 const scheduleStart = (myGeneration: number): void => {
-  // Sites that populate their article images lazily (see shouldWaitForFullLoad)
-  // hand Defuddle placeholder srcs at DOMContentLoaded — wait for the window
-  // `load` event, by which the images have resolved, before parsing.
+  // Lazy-image sites: wait for window `load` so real srcs have resolved.
   if (shouldWaitForFullLoad()) {
     if (document.readyState === 'complete') {
       startIfEligible(myGeneration);
@@ -128,9 +126,7 @@ const scheduleStart = (myGeneration: number): void => {
     return;
   }
 
-  // DOMContentLoaded only fires once, on the loading -> interactive
-  // transition — attaching this listener after that point (e.g. toggled
-  // mid-load) means it never fires, leaving the loader up forever.
+  // DOMContentLoaded fires once; attach only while still loading.
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', () => {
       startIfEligible(myGeneration);

--- a/src/readability/heuristics.ts
+++ b/src/readability/heuristics.ts
@@ -49,11 +49,7 @@ export const shouldRunOnUrl = (): boolean => {
   return true;
 };
 
-// Sites that attach or populate their article images lazily, after the initial
-// DOM is parsed (e.g. NYTimes swaps in real srcs post-load) — Defuddle run at
-// DOMContentLoaded captures placeholder/missing srcs. For these, defer the
-// parse to the window `load` event, by which the above-the-fold images have
-// resolved their real srcs.
+// Sites that populate article images lazily, after DOMContentLoaded.
 const DEFERRED_IMAGE_HOSTS = ['nytimes.com'];
 
 export const shouldWaitForFullLoad = (): boolean =>

--- a/src/readability/index.scss
+++ b/src/readability/index.scss
@@ -30,8 +30,8 @@
     --main-foreground: #cac5bc;
     --muted-foreground: #96918a;
     --border-color: #3c3a36;
-    --link-color: #6cb6ff;
-    --link-visited-color: #c792ea;
+    --link-color: #6197d0;
+    --link-visited-color: #a87fc4;
   }
 }
 

--- a/src/readability/index.scss
+++ b/src/readability/index.scss
@@ -15,10 +15,6 @@
   --border-color: #e4ddcf;
   --link-color: #0b6fb3;
   --link-visited-color: #7c3fa8;
-  // Soft, two-layer drop shadow tinted with the theme's ink — a tight contact
-  // shadow plus a wider ambient one, so images sit on the page rather than
-  // float. On dark, a plain shadow vanishes against near-black, so the first
-  // layer is a hairline light ring that defines the image edge instead.
   --image-shadow: 0 1px 3px rgba(43, 41, 38, 0.1),
     0 10px 28px rgba(43, 41, 38, 0.14);
 

--- a/src/readability/index.scss
+++ b/src/readability/index.scss
@@ -15,6 +15,12 @@
   --border-color: #e4ddcf;
   --link-color: #0b6fb3;
   --link-visited-color: #7c3fa8;
+  // Soft, two-layer drop shadow tinted with the theme's ink — a tight contact
+  // shadow plus a wider ambient one, so images sit on the page rather than
+  // float. On dark, a plain shadow vanishes against near-black, so the first
+  // layer is a hairline light ring that defines the image edge instead.
+  --image-shadow: 0 1px 3px rgba(43, 41, 38, 0.1),
+    0 10px 28px rgba(43, 41, 38, 0.14);
 
   &.sepia {
     --main-background: #f4ecd8;
@@ -23,6 +29,8 @@
     --border-color: #e0cfab;
     --link-color: #9c5c1f;
     --link-visited-color: #7a4518;
+    --image-shadow: 0 1px 3px rgba(91, 70, 54, 0.12),
+      0 10px 28px rgba(91, 70, 54, 0.16);
   }
 
   &.dark {
@@ -32,6 +40,8 @@
     --border-color: #3c3a36;
     --link-color: #6197d0;
     --link-visited-color: #a87fc4;
+    --image-shadow: 0 0 0 1px rgba(202, 197, 188, 0.08),
+      0 12px 32px rgba(0, 0, 0, 0.55);
   }
 }
 

--- a/src/readability/loader-styles.ts
+++ b/src/readability/loader-styles.ts
@@ -1,10 +1,7 @@
-// Styles for the reader loading screen. Kept as a string builder (not a real
-// .css file) so it can be injected synchronously at document_start — the themed
-// background must paint before the browser's first frame, which rules out
-// fetching an extracted stylesheet at runtime.
+// String builder (not a real .css file) so it can be injected synchronously
+// at document_start, ahead of the browser's first paint.
 
-// Jade/teal ink accent for the "title" line — stands apart from the warm paper
-// themes. Swap this one constant to retint the animation.
+// Jade/teal accent for the "title" line — swap to retint the animation.
 const ACCENT = '#2f9e8f';
 
 export const LOADER_ART_ID = 'stylebot-reader-loading-art';
@@ -14,11 +11,7 @@ export type LoaderColors = {
   foreground: string;
 };
 
-/**
- * Build the loading-screen CSS for the given theme colors. `lineCount` drives
- * the staggered per-line animation delays so the "written lines" ripple stays
- * in sync with however many skeleton lines the DOM renders.
- */
+// Build the loading-screen CSS for the given theme colors and line count.
 export const loaderCss = (
   { background, foreground }: LoaderColors,
   lineCount: number
@@ -31,29 +24,21 @@ export const loaderCss = (
   ).join(' ');
 
   return (
-    // Also paint body: the page's own <body> parses after document_start and
-    // may carry an opaque (often white) background that would otherwise paint
-    // over the themed html background before the reader mounts.
+    // Paint body too — it parses after document_start and can be opaque.
     `html, body { background: ${background} !important; } ` +
     'body { border: 0 !important; box-shadow: none !important; } ' +
     'body *:not(#stylebot) { display: none; }' +
-    // The loader art lives directly under <html> (outside body), so it's
-    // unaffected by the body-child hide rule above.
     `#${LOADER_ART_ID} {` +
     '  position: fixed; inset: 0; margin: auto;' +
     '  width: 130px; height: -moz-fit-content; height: fit-content;' +
     '  display: flex; flex-direction: column; gap: 8px;' +
     '  z-index: 2147483647; pointer-events: none; opacity: 0;' +
-    // Only fade the whole skeleton in after a delay — a reader that mounts
-    // quickly removes the loader first, so fast loads show nothing and only
-    // real waits (e.g. deferred lazy-image hosts) reveal the animation.
+    // Fade in only after a delay, so fast loads show nothing.
     '  animation: stylebot-reader-fade-in 0.25s ease-out 0.6s forwards;' +
     '}' +
     `#${LOADER_ART_ID} > i {` +
     '  display: block; height: 7px; border-radius: 3px;' +
     `  background: ${foreground}; opacity: 0.45;` +
-    // Each line grows from the left ("written") then clears, staggered per line
-    // below, so the article appears to be laid out into clean lines.
     '  transform: scaleX(0); transform-origin: left center;' +
     '  animation: stylebot-reader-write 1.8s ease-in-out infinite;' +
     '}' +

--- a/src/readability/loader.ts
+++ b/src/readability/loader.ts
@@ -38,12 +38,7 @@ export const cacheTheme = (theme: ReadabilityTheme): void => {
   }
 };
 
-/**
- * Hide document content until reader is ready
- * todo: optimize performance and UX when loading stylebot reader
- * currently, sometimes the page flashes before the reader content is loaded.
- * or a white screen appears for a prolonged period, especially for slower websites.
- */
+// Hide document content until reader is ready.
 export const showLoader = (): void => {
   let cachedTheme: ReadabilityTheme | null = null;
 
@@ -56,11 +51,8 @@ export const showLoader = (): void => {
   const background = (cachedTheme && THEME_BACKGROUNDS[cachedTheme]) || THEME_BACKGROUNDS.light;
   const foreground = (cachedTheme && THEME_FOREGROUNDS[cachedTheme]) || THEME_FOREGROUNDS.light;
 
-  // Paint the themed background inline on documentElement, synchronously and
-  // ahead of any stylesheet parse. An injected <style> only takes effect after
-  // a CSSOM parse + style recalc; an inline root style commits immediately, so
-  // the browser has the theme color for its first paint rather than the default
-  // white canvas.
+  // Set inline (not via <style>) so it commits before any CSSOM parse/recalc,
+  // ahead of the browser's first paint.
   document.documentElement.style.setProperty('background', background, 'important');
 
   const style = document.createElement('style');

--- a/src/readability/scss/content.scss
+++ b/src/readability/scss/content.scss
@@ -70,7 +70,7 @@
 
   img {
     width: auto;
-    max-height: 80vh;
+    max-height: 60vh;
     max-width: 92%;
   }
 

--- a/src/readability/scss/content.scss
+++ b/src/readability/scss/content.scss
@@ -68,6 +68,17 @@
     height: auto;
   }
 
+  img {
+    // Cap tall/portrait images — regardless of how they're wrapped — so a single
+    // hero, infographic, or full-page scan can't exceed the viewport and shove
+    // the article far down. width is already bounded to the reading column by
+    // the `*` rule; width:auto + max-height lets the browser scale height down
+    // here while preserving aspect ratio. max-height only ever shrinks, so tiny
+    // icons/emoji are unaffected.
+    width: auto;
+    max-height: 80vh;
+  }
+
   p,
   code,
   pre,

--- a/src/readability/scss/content.scss
+++ b/src/readability/scss/content.scss
@@ -69,9 +69,12 @@
   }
 
   img {
+    display: block;
     width: auto;
     max-height: 60vh;
     max-width: 92%;
+    margin-inline: auto;
+    margin-bottom: 20px;
   }
 
   p,
@@ -99,15 +102,6 @@
 
   p > img:only-child,
   p > a:only-child > img:only-child,
-  .wp-caption img,
-  figure img,
-  img[moz-reader-center] {
-    display: block;
-    margin-inline: auto;
-  }
-
-  p > img:only-child,
-  p > a:only-child > img:only-child,
   td[colspan] img,
   .wp-caption img,
   figure img,
@@ -121,6 +115,7 @@
   figcaption {
     display: block;
     margin-top: 0.6em;
+    margin-bottom: 20px;
     text-align: center;
     font-size: 0.9em;
     line-height: 1.48em;

--- a/src/readability/scss/content.scss
+++ b/src/readability/scss/content.scss
@@ -118,7 +118,7 @@
   figure img,
   img[moz-reader-center] {
     border-radius: 8px;
-    box-shadow: 0 2px 8px color-mix(in srgb, var(--main-foreground) 20%, transparent);
+    box-shadow: var(--image-shadow);
   }
 
   .caption,

--- a/src/readability/scss/content.scss
+++ b/src/readability/scss/content.scss
@@ -69,14 +69,9 @@
   }
 
   img {
-    // Cap tall/portrait images — regardless of how they're wrapped — so a single
-    // hero, infographic, or full-page scan can't exceed the viewport and shove
-    // the article far down. width is already bounded to the reading column by
-    // the `*` rule; width:auto + max-height lets the browser scale height down
-    // here while preserving aspect ratio. max-height only ever shrinks, so tiny
-    // icons/emoji are unaffected.
     width: auto;
     max-height: 80vh;
+    max-width: 92%;
   }
 
   p,
@@ -133,8 +128,6 @@
     color: var(--muted-foreground);
   }
 
-  // Decorative credit/type icons (camera, play button, etc.) — the caption
-  // text already states this, and the icon loses its source page's spacing.
   figcaption svg {
     display: none;
   }
@@ -195,8 +188,6 @@
     background: color-mix(in srgb, var(--main-foreground) 6%, transparent);
   }
 
-  // Infobox image rows span both columns via colspan — the image is often
-  // nested too deep for margin-auto, so center via the cell's text-align.
   td[colspan] {
     text-align: center;
   }
@@ -215,7 +206,6 @@
     border-inline-end: 0;
   }
 
-  /* Visually hide (but don't display: none) screen reader elements */
   .visually-hidden,
   .visuallyhidden,
   .sr-only {
@@ -228,19 +218,15 @@
     border-width: 0;
   }
 
-  /* Hide elements with common "hidden" class names */
   .hidden,
   .invisible {
     display: none;
   }
 
-  /* Enforce wordpress and similar emoji/smileys aren't sized to be full-width,
- * see bug 1399616 for context. */
   img.wp-smiley,
   img.emoji {
     display: inline-block;
     border-width: 0;
-    /* height: auto is implied from `.stylebot-reader-content *` rule. */
     width: 1em;
     margin: 0 0.07em;
     padding: 0;

--- a/src/readability/scss/content.scss
+++ b/src/readability/scss/content.scss
@@ -143,10 +143,21 @@
   }
 
   blockquote {
-    padding: 0;
-    padding-inline-start: 16px;
+    margin: 8px 0 28px;
+    padding-block: 14px;
+    padding-inline: 20px;
     border-inline-start: 3px solid var(--link-color);
-    color: var(--muted-foreground);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--link-color) 8%, transparent);
+    color: var(--main-foreground);
+  }
+
+  blockquote > :first-child {
+    margin-top: 0;
+  }
+
+  blockquote > :last-child {
+    margin-bottom: 0;
   }
 
   ul,

--- a/src/readability/utils.ts
+++ b/src/readability/utils.ts
@@ -62,6 +62,18 @@ const withLeadImage = (content: string, imageUrl?: string): string => {
 
 const normalizeText = (text: string): string => text.replace(/\s+/g, ' ').trim();
 
+// Ad-slot labels (e.g. NYT's "Advertisement" / "SKIP ADVERTISEMENT") that sit
+// inline in the article flow and read as real content to Defuddle.
+const AD_MARKER_PATTERN = /^(advertisement|skip advertisement)$/i;
+
+const removeAdMarkers = (doc: Document): void => {
+  doc.querySelectorAll('p, div, span, a, h1, h2, h3, h4, h5, h6').forEach(el => {
+    if (el.children.length === 0 && AD_MARKER_PATTERN.test(normalizeText(el.textContent || ''))) {
+      el.remove();
+    }
+  });
+};
+
 // Defuddle's hero-block cleanup can drop a real subheadline as empty chrome;
 // article.description survives that removal, so recover it here.
 const withDescription = (content: string, description?: string): string => {
@@ -85,6 +97,8 @@ const withDescription = (content: string, description?: string): string => {
 // document must stay intact until reader mode is confirmed to apply.
 export const getReadabilityArticle = async (): Promise<ReadabilityArticle> => {
   const doc = document.cloneNode(true) as Document;
+
+  removeAdMarkers(doc);
 
   // The clone has no defaultView, so Defuddle's small-image filter can't
   // measure rendered size — copy naturalWidth/Height from the live images.

--- a/src/readability/utils.ts
+++ b/src/readability/utils.ts
@@ -7,10 +7,8 @@ export const getDomainUrlAndSource = (): { url: string; source: string } => {
   return { url: `${parts[0]}//${parts[2]}`, source: parts[2] };
 };
 
-// Sites often serve the same photo under multiple resized-variant URLs (a
-// different filename suffix, e.g. NYT's "-facebookJumbo" vs
-// "-mobileMasterAt3x", or a different resize query param) — comparing raw
-// URLs misses these, so compare directory + filename-prefix instead.
+// Sites serve the same photo under multiple resized-variant URLs, so compare
+// directory + filename-prefix instead of raw URLs.
 const imageIdentity = (url: string): { directory: string; stem: string } => {
   const withoutQuery = url.split('?')[0];
   const lastSlash = withoutQuery.lastIndexOf('/');
@@ -21,9 +19,8 @@ const imageIdentity = (url: string): { directory: string; stem: string } => {
   };
 };
 
-// A shared directory alone isn't enough — WordPress groups a whole month's
-// unrelated uploads under one directory — so also require the filenames to
-// share a meaningful prefix (the part before a size/variant suffix).
+// A shared directory alone isn't enough (WordPress groups a month's uploads
+// together), so also require a shared filename prefix.
 const isSameImage = (a: string, b: string): boolean => {
   const idA = imageIdentity(a);
   const idB = imageIdentity(b);
@@ -40,10 +37,8 @@ const isSameImage = (a: string, b: string): boolean => {
   return sharedPrefixLength >= Math.min(idA.stem.length, idB.stem.length) * 0.5;
 };
 
-// WordPress (and others) often render the hero image as a sibling of the
-// content container Defuddle scopes to, so it's resolved in metadata but
-// missing from `content` — build the tag via the DOM so the URL is safely
-// escaped, rather than interpolating it into an HTML string.
+// The hero image is often resolved in metadata but missing from `content`;
+// build the tag via the DOM so the URL is safely escaped.
 const withLeadImage = (content: string, imageUrl?: string): string => {
   if (!imageUrl || !/^https?:\/\//.test(imageUrl)) {
     return content;
@@ -67,10 +62,8 @@ const withLeadImage = (content: string, imageUrl?: string): string => {
 
 const normalizeText = (text: string): string => text.replace(/\s+/g, ' ').trim();
 
-// Defuddle's own "hero header block" cleanup treats a title+time+dek wrapper
-// as empty metadata chrome and deletes it whenever the dek reads as under 30
-// words of "prose" — dropping real subheadline text along with it. Its
-// article.description metadata survives that removal, so recover it here.
+// Defuddle's hero-block cleanup can drop a real subheadline as empty chrome;
+// article.description survives that removal, so recover it here.
 const withDescription = (content: string, description?: string): string => {
   if (!description) {
     return content;
@@ -88,23 +81,13 @@ const withDescription = (content: string, description?: string): string => {
   return `${p.outerHTML}${content}`;
 };
 
-/**
- * Parse a clone of the live document — Defuddle mutates whatever it's
- * given (strips scripts/styles etc.), so the original document must stay
- * intact until reader mode is confirmed to apply.
- */
+// Parse a clone — Defuddle mutates whatever it's given, so the original
+// document must stay intact until reader mode is confirmed to apply.
 export const getReadabilityArticle = async (): Promise<ReadabilityArticle> => {
   const doc = document.cloneNode(true) as Document;
 
-  // Defuddle's small-image filter (icons, tracking pixels) needs each image's
-  // rendered size, but it only measures when doc.defaultView === window — and a
-  // cloned document has no defaultView. Measuring the live DOM wouldn't help
-  // either: by parse time the loader has display:none'd the page, so
-  // getBoundingClientRect reads 0. naturalWidth/Height is immune to both (it's
-  // the intrinsic pixel size of the decoded image), so copy it from the live
-  // images onto the clone as width/height attributes — the same attributes the
-  // filter reads — replacing any misleading authored dimensions. cloneNode
-  // preserves image order, so the collections line up by index.
+  // The clone has no defaultView, so Defuddle's small-image filter can't
+  // measure rendered size — copy naturalWidth/Height from the live images.
   const liveImages = document.images;
   const clonedImages = doc.images;
 

--- a/src/readability/utils.ts
+++ b/src/readability/utils.ts
@@ -96,11 +96,28 @@ const withDescription = (content: string, description?: string): string => {
 export const getReadabilityArticle = async (): Promise<ReadabilityArticle> => {
   const doc = document.cloneNode(true) as Document;
 
-  const article = new Defuddle(doc, {
-    // The clone has no defaultView, so Defuddle's small-image filter can't
-    // read rendered size and falls back to (often-wrong) width/height attrs.
-    removeSmallImages: false,
-  }).parse();
+  // Defuddle's small-image filter (icons, tracking pixels) needs each image's
+  // rendered size, but it only measures when doc.defaultView === window — and a
+  // cloned document has no defaultView. Measuring the live DOM wouldn't help
+  // either: by parse time the loader has display:none'd the page, so
+  // getBoundingClientRect reads 0. naturalWidth/Height is immune to both (it's
+  // the intrinsic pixel size of the decoded image), so copy it from the live
+  // images onto the clone as width/height attributes — the same attributes the
+  // filter reads — replacing any misleading authored dimensions. cloneNode
+  // preserves image order, so the collections line up by index.
+  const liveImages = document.images;
+  const clonedImages = doc.images;
+
+  for (let i = 0; i < clonedImages.length; i++) {
+    const live = liveImages[i];
+
+    if (live && live.naturalWidth > 0 && live.naturalHeight > 0) {
+      clonedImages[i].setAttribute('width', String(live.naturalWidth));
+      clonedImages[i].setAttribute('height', String(live.naturalHeight));
+    }
+  }
+
+  const article = new Defuddle(doc).parse();
 
   if (!article || !article.content) {
     throw new Error('Defuddle failed to parse the page');


### PR DESCRIPTION
## Summary
- Dim dark-mode reader links
- Cap reader image height at 80vh, then further reduce to 60vh
- Re-enable Defuddle's small-image removal using intrinsic sizes
- Theme the reader image shadow per light/sepia/dark
- Trim comments and strip CSS comments
- Give reader blockquotes a distinct card treatment
- Strip inline ad-slot labels from reader content
- Fix reader image/caption vertical rhythm and centering

Stacked on `readability/04-loading-experience`. Part of an incremental
breakup of `spike/defuddle-readability` — see the full PR chain (01 through 08).

## Test plan
- [ ] Open reader mode in dark theme and confirm links are readable, not
      overly bright
- [ ] Confirm images are capped at a reasonable height and don't dominate
      the viewport
- [ ] Confirm blockquotes render with a distinct visual treatment
- [ ] Confirm no small tracking-pixel/icon images leak into extracted
      content, and that "Advertisement"/ad-slot labels don't appear