### PR TITLE
refactor: drop the @mozilla/readability dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "@babel/core": "^7.10.1",
     "@babel/plugin-proposal-optional-chaining": "^7.10.1",
     "@babel/preset-env": "^7.10.1",
-    "@mozilla/readability": "^0.6.0",
     "@types/chrome": "^0.0.193",
     "@types/dedent": "^0.7.0",
     "@types/jest": "^26.0.4",

--- a/src/readability/heuristics.ts
+++ b/src/readability/heuristics.ts
@@ -1,4 +1,4 @@
-import { isProbablyReaderable } from '@mozilla/readability';
+import { isProbablyReaderable } from './is-probably-readerable';
 
 // A single short, barely-hyphenated path segment reads as a section/category
 // name (e.g. "tech", "news") rather than a full article slug.

--- a/src/readability/is-probably-readerable.ts
+++ b/src/readability/is-probably-readerable.ts
@@ -1,0 +1,83 @@
+/*
+ * Adapted from @mozilla/readability's Readability-readerable.js.
+ * Copyright (c) 2010 Arc90 Inc.
+ * Licensed under the Apache License, Version 2.0:
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// NOTE: kept in sync with Mozilla's own copy — see their comment on this
+// duplication in Readability-readerable.js.
+const UNLIKELY_CANDIDATES =
+  /-ad-|ai2html|banner|breadcrumbs|combx|comment|community|cover-wrap|disqus|extra|footer|gdpr|header|legends|menu|related|remark|replies|rss|shoutbox|sidebar|skyscraper|social|sponsor|supplemental|ad-break|agegate|pagination|pager|popup|yom-remote/i;
+const OK_MAYBE_ITS_A_CANDIDATE = /and|article|body|column|content|main|shadow/i;
+
+// Have to null-check style/className for SVG and MathML nodes.
+const isNodeVisible = (node: Element): boolean =>
+  (!(node as HTMLElement).style || (node as HTMLElement).style.display !== 'none') &&
+  !node.hasAttribute('hidden') &&
+  (!node.hasAttribute('aria-hidden') ||
+    node.getAttribute('aria-hidden') !== 'true' ||
+    // Wikimedia math images rely on a visible "fallback-image" node.
+    !!node.className?.includes?.('fallback-image'));
+
+export type IsProbablyReaderableOptions = {
+  minScore?: number;
+  minContentLength?: number;
+  visibilityChecker?: (node: Element) => boolean;
+};
+
+// Decides whether a document is reader-able without parsing the whole thing.
+export const isProbablyReaderable = (
+  doc: Document,
+  options: IsProbablyReaderableOptions = {}
+): boolean => {
+  const {
+    minScore = 20,
+    minContentLength = 140,
+    visibilityChecker = isNodeVisible,
+  } = options;
+
+  let nodes: Element[] = Array.from(doc.querySelectorAll('p, pre, article'));
+
+  // Some articles' DOM looks like <div>Sentence<br><br>Sentence<br></div> —
+  // fold in the parent <div> of any <br> so those still count.
+  const brNodes = doc.querySelectorAll('div > br');
+  if (brNodes.length) {
+    const set = new Set(nodes);
+    brNodes.forEach(node => {
+      if (node.parentNode instanceof Element) {
+        set.add(node.parentNode);
+      }
+    });
+    nodes = Array.from(set);
+  }
+
+  let score = 0;
+
+  return nodes.some(node => {
+    if (!visibilityChecker(node)) {
+      return false;
+    }
+
+    const matchString = `${node.className} ${node.id}`;
+    if (
+      UNLIKELY_CANDIDATES.test(matchString) &&
+      !OK_MAYBE_ITS_A_CANDIDATE.test(matchString)
+    ) {
+      return false;
+    }
+
+    if (node.matches('li p')) {
+      return false;
+    }
+
+    const textContentLength = (node.textContent ?? '').trim().length;
+    if (textContentLength < minContentLength) {
+      return false;
+    }
+
+    score += Math.sqrt(textContentLength - minContentLength);
+
+    return score > minScore;
+  });
+};

--- a/src/readability/reader.ts
+++ b/src/readability/reader.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { isProbablyReaderable } from '@mozilla/readability';
+import { isProbablyReaderable } from './is-probably-readerable';
 
 import App from './App.vue';
 import { getDomainUrlAndSource, getReadabilityArticle } from './utils';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -123,16 +123,6 @@ const config = {
         },
       },
       {
-        // Ships modern syntax (e.g. `??`) that webpack 4's parser can't
-        // read; nothing else in node_modules needs this, so scope it down.
-        test: /\.js$/,
-        include: /node_modules[\\/]@mozilla[\\/]readability/,
-        loader: 'babel-loader',
-        options: {
-          presets: ['@babel/preset-env'],
-        },
-      },
-      {
         test: /\.((c|sa|sc)ss)$/i,
         use: [
           MiniCssExtractPlugin.loader,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,11 +1107,6 @@
   resolved "https://registry.yarnpkg.com/@mixmark-io/domino/-/domino-2.2.0.tgz#4e8ec69bf1afeb7a14f0628b7e2c0f35bdb336c3"
   integrity sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==
 
-"@mozilla/readability@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@mozilla/readability/-/readability-0.6.0.tgz#134e3ce3ff1676716e550de0b8de957bcc59208b"
-  integrity sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==
-
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"


### PR DESCRIPTION
## Summary
The only thing used from `@mozilla/readability` was `isProbablyReaderable()`
— actual article extraction is handled entirely by Defuddle (see PR 03).
Ports the function directly, keeping the original Apache-2.0 license header,
and removes the now-dead webpack rule that existed solely to transpile that
package's modern syntax for webpack 4.

Stacked on `readability/06-settings-dock`. Part of an incremental breakup of
`spike/defuddle-readability` — see the full PR chain (01 through 08).

## Test plan
- [ ] `yarn build && yarn lint && yarn test` all pass
- [ ] Confirm the readability toggle still correctly enables/disables per
      page eligibility (unlikely-candidate URLs, MediaWiki main pages, etc.)