### PR TITLE
feat: polish popup readability domain label and copy

### DIFF
--- a/src/_locales/en.config
+++ b/src/_locales/en.config
@@ -261,7 +261,7 @@ Readability
 Enable Readability
 
 @readability_description
-Make articles on this site readable by hiding non-essential page elements like sidebars, footers and ads.
+Turn this site's articles into a clean, distraction-free reading view, with your choice of theme, font, and size.
 
 @theme
 Theme

--- a/src/_locales/en_GB.config
+++ b/src/_locales/en_GB.config
@@ -261,7 +261,7 @@ Readability
 Enable Readability
 
 @readability_description
-Make articles on this site readable by hiding non-essential page elements like sidebars, footers and ads.
+Turn this site's articles into a clean, distraction-free reading view, with your choice of theme, font, and size.
 
 @theme
 Theme

--- a/src/_locales/en_US.config
+++ b/src/_locales/en_US.config
@@ -261,7 +261,7 @@ Readability
 Enable Readability
 
 @readability_description
-Make articles on this site readable by hiding non-essential page elements like sidebars, footers and ads.
+Turn this site's articles into a clean, distraction-free reading view, with your choice of theme, font, and size.
 
 @theme
 Theme

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -10,6 +10,7 @@
       />
 
       <readability
+        :domain="domain"
         :initial-readability="pageReaderable && readability"
         :disabled="!pageReaderable"
         @change="readability = $event"
@@ -77,6 +78,16 @@ export default Vue.extend({
       googleDriveSyncEnabled: false,
       googleDriveSyncMetadata: undefined,
     };
+  },
+
+  computed: {
+    domain(): string {
+      try {
+        return this.tab?.url ? new URL(this.tab.url).hostname : '';
+      } catch {
+        return '';
+      }
+    },
   },
 
   created() {

--- a/src/popup/components/Readability.vue
+++ b/src/popup/components/Readability.vue
@@ -11,7 +11,8 @@
       :disabled="disabled"
       @change="onChange"
     >
-      {{ t('readability') }}
+      <div>{{ t('readability') }}</div>
+      <div v-if="domain" class="readability-domain">{{ domain }}</div>
     </b-form-checkbox>
   </b-list-group-item>
 </template>
@@ -23,6 +24,10 @@ import { ToggleReadabilityForTab } from '@stylebot/types';
 export default Vue.extend({
   name: 'Readability',
   props: {
+    domain: {
+      type: String,
+      default: '',
+    },
     initialReadability: Boolean,
     disabled: Boolean,
   },
@@ -75,3 +80,11 @@ export default Vue.extend({
   },
 });
 </script>
+
+<style lang="scss" scoped>
+.readability-domain {
+  font-size: 12px;
+  color: #888;
+  margin-top: 2px;
+}
+</style>


### PR DESCRIPTION
## Summary
- Show the current site's domain under the popup's Readability toggle,
  making it clear the toggle applies to the whole domain
- Rewrite readability_description to reflect the full feature set (theme/
  font/size customization), not just clutter-removal

Stacked on `readability/07-drop-mozilla-dep`. Final PR in the incremental
breakup of `spike/defuddle-readability` (01 through 08).

## Test plan
- [ ] Open the popup on an article page — confirm the domain shows under
      the Readability toggle
- [ ] Open the editor's Magic panel — confirm the updated description text