### PR TITLE
fix: editor keyboard shortcuts not working on first open

### DIFF
--- a/src/editor/components/shortcuts/TheKeyboardShortcuts.vue
+++ b/src/editor/components/shortcuts/TheKeyboardShortcuts.vue
@@ -46,12 +46,17 @@ export default Vue.extend({
   },
 
   watch: {
-    visible(newValue: boolean): void {
-      if (newValue) {
-        this.attachStylebotShortcuts();
-      } else {
-        this.detachStylebotShortcuts();
-      }
+    visible: {
+      // `visible` can already be true by the time this mounts, so a
+      // non-immediate watcher would miss attaching the listener.
+      immediate: true,
+      handler(newValue: boolean): void {
+        if (newValue) {
+          this.attachStylebotShortcuts();
+        } else {
+          this.detachStylebotShortcuts();
+        }
+      },
     },
   },
 

--- a/src/editor/components/shortcuts/__tests__/TheKeyboardShortcuts.test.ts
+++ b/src/editor/components/shortcuts/__tests__/TheKeyboardShortcuts.test.ts
@@ -1,0 +1,60 @@
+import { shallowMount } from '@vue/test-utils';
+
+import { defaultEditorCommands } from '@stylebot/settings';
+import TheKeyboardShortcuts from '../TheKeyboardShortcuts.vue';
+
+interface TheKeyboardShortcutsInstance extends Vue {
+  detachStylebotShortcuts(): void;
+}
+
+const buildMockStore = (visible: boolean) => ({
+  state: {
+    visible,
+    help: false,
+    inspecting: false,
+    resizing: false,
+    activeSelector: '',
+    options: {
+      mode: 'basic',
+      layout: { dockLocation: 'right', adjustPageLayout: false },
+    },
+    editorCommands: defaultEditorCommands,
+  },
+  getters: { activeRule: undefined },
+  commit: jest.fn(),
+  dispatch: jest.fn(),
+});
+
+describe('TheKeyboardShortcuts.vue', () => {
+  let wrapper: ReturnType<typeof shallowMount> | undefined;
+
+  afterEach(() => {
+    // the shortcut listener is attached directly on `document`, outside of
+    // Vue's lifecycle, so it must be detached manually between tests.
+    (wrapper?.vm as TheKeyboardShortcutsInstance | undefined)?.detachStylebotShortcuts();
+    wrapper?.destroy();
+    wrapper = undefined;
+  });
+
+  it('attaches the shortcut listener immediately when mounted with the editor already visible', () => {
+    const store = buildMockStore(true);
+    wrapper = shallowMount(TheKeyboardShortcuts, { mocks: { $store: store } });
+
+    document.body.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+    );
+
+    expect(store.dispatch).toHaveBeenCalledWith('closeStylebot');
+  });
+
+  it('does not attach the shortcut listener when mounted with the editor hidden', () => {
+    const store = buildMockStore(false);
+    wrapper = shallowMount(TheKeyboardShortcuts, { mocks: { $store: store } });
+
+    document.body.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+    );
+
+    expect(store.dispatch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Shortcuts inside the editor (inspect, dock, resize, help, close, etc.) silently didn't work the first time the editor was opened on a page — they'd only start working after closing and reopening once.
- Cause: `openStylebot` sets `visible = true` before the editor app finishes mounting (mount is deferred until a CSS fetch resolves), so `TheKeyboardShortcuts`'s non-immediate `visible` watcher missed that first transition and never attached the keydown listener.
- Fix: mark the watcher `immediate: true` so it also runs against the current value at mount.

## Test plan
- [x] Manually verified: open the editor for the first time on a fresh page load and confirm shortcuts (e.g. `i`, `Escape`) work immediately.
- [x] `yarn lint` and `yarn test` pass.