### PR TITLE
Add Playwright e2e testing harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ node_modules
 yarn-error.log
 coverage
 .history
+test-results
+playwright-report

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,91 @@
+import { test as base, chromium, type BrowserContext, type Page } from '@playwright/test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const DIST_PATH = path.resolve(__dirname, '..', 'dist');
+
+export const test = base.extend<{
+  context: BrowserContext;
+  extensionId: string;
+  openPopup: () => Promise<Page>;
+}>({
+  context: async ({}, use, testInfo) => {
+    if (!fs.existsSync(DIST_PATH)) {
+      throw new Error(
+        `No build found at ${DIST_PATH} — run \`yarn build\` before the e2e suite (\`yarn test:e2e\` does this for you).`
+      );
+    }
+
+    const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stylebot-e2e-'));
+
+    // --headed/--debug don't reach our manual browser launch, but they do flip this.
+    const headless = testInfo.project.use.headless ?? true;
+
+    // Chrome 137+ removed --load-extension; CDP's Extensions domain replaces it below.
+    const context = await chromium.launchPersistentContext(userDataDir, {
+      headless,
+      channel: 'chrome',
+      chromiumSandbox: true,
+      viewport: null,
+      ignoreDefaultArgs: [
+        // Playwright disables extensions by default, which would block our CDP-loaded one.
+        '--disable-extensions',
+        '--enable-automation',
+      ],
+      args: [
+        // Required for Extensions.loadUnpacked.
+        '--enable-unsafe-extension-debugging',
+      ],
+    });
+
+    // The extension opens this on fresh install, stealing tab focus.
+    const closeHelpTab = (p: Page) => {
+      if (/^https:\/\/stylebot\.dev\/help/.test(p.url())) {
+        p.close().catch(() => {});
+      }
+    };
+    context.on('page', p => {
+      closeHelpTab(p);
+      p.once('framenavigated', () => closeHelpTab(p));
+    });
+
+    // Our custom context bypasses Playwright's default trace/video wiring, so start it manually.
+    await context.tracing.start({ screenshots: true, snapshots: true });
+
+    await use(context);
+
+    const tracePath = testInfo.outputPath('trace.zip');
+    await context.tracing.stop({ path: tracePath });
+    // Named 'trace' so the HTML reporter shows its built-in "View trace" button.
+    await testInfo.attach('trace', { path: tracePath, contentType: 'application/zip' });
+    await context.close();
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  },
+
+  extensionId: async ({ context }, use) => {
+    const cdp = await context.browser()!.newBrowserCDPSession();
+    const { id } = await cdp.send('Extensions.loadUnpacked', { path: DIST_PATH });
+
+    await use(id);
+  },
+
+  // Opens the popup by URL (Playwright can't click a real toolbar icon), in the
+  // background so it doesn't steal "current tab" from the page under test.
+  openPopup: async ({ context, extensionId }, use) => {
+    const cdp = await context.browser()!.newBrowserCDPSession();
+
+    const popupUrl = `chrome-extension://${extensionId}/popup/index.html`;
+
+    const open = async (): Promise<Page> => {
+      // Filtered so the onInstalled help tab can't win this race instead.
+      const pagePromise = context.waitForEvent('page', p => p.url() === popupUrl);
+      await cdp.send('Target.createTarget', { url: popupUrl, background: true });
+      return pagePromise;
+    };
+
+    await use(open);
+  },
+});
+
+export const expect = test.expect;

--- a/e2e/open-in-current-tab.spec.ts
+++ b/e2e/open-in-current-tab.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from './fixtures';
+
+test('opening Stylebot from the popup opens the editor in the current tab', async ({
+  context,
+  openPopup,
+}) => {
+  const page = await context.newPage();
+  await page.goto('https://example.com');
+
+  // init-editor.ts mounts the editor under this host once ToggleStylebot reaches it.
+  await expect(page.locator('#stylebot')).toHaveCount(0);
+
+  // Pins this as the "active" tab, in case the onInstalled help tab grabbed focus.
+  await page.bringToFront();
+
+  // The popup calls window.close() right after sending the toggle message, which
+  // races a plain .click()'s post-click stability wait — dispatch instead.
+  const popup = await openPopup();
+  await popup.locator('.open-stylebot').dispatchEvent('click');
+
+  // The host is deliberately 0x0 (see init-editor.ts) — assert presence, not visibility.
+  await expect(page.locator('#stylebot')).toBeAttached();
+});

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from './fixtures';
+
+test('reveals the page after the content script runs', async ({ context }) => {
+  const page = await context.newPage();
+  await page.goto('https://example.com');
+
+  // hide-page.ts adds this at document_start, removes it once storage resolves.
+  // A leftover element means the reveal hung — the load white flash bug.
+  await expect(page.locator('#stylebot-hide-page')).toHaveCount(0);
+});
+
+test('popup mounts and renders the open-editor toggle', async ({ context, extensionId }) => {
+  const popup = await context.newPage();
+  await popup.goto(`chrome-extension://${extensionId}/popup/index.html`);
+
+  // Proves the popup's Vue app mounts without throwing — the direct symptom
+  // of the "won't open" bug cluster is a blank or broken popup here.
+  await expect(popup.locator('.open-stylebot')).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "postinstall": "patch-package"
   },
   "jest": {
+    "roots": [
+      "<rootDir>/src"
+    ],
     "moduleFileExtensions": [
       "js",
       "ts",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "test:coverage": "jest --coverage",
+    "test:e2e": "yarn build && playwright test",
     "postinstall": "patch-package"
   },
   "jest": {
@@ -63,6 +64,7 @@
     "@babel/core": "^7.10.1",
     "@babel/plugin-proposal-optional-chaining": "^7.10.1",
     "@babel/preset-env": "^7.10.1",
+    "@playwright/test": "1.63.0",
     "@types/chrome": "^0.0.193",
     "@types/dedent": "^0.7.0",
     "@types/jest": "^26.0.4",
@@ -102,7 +104,7 @@
     "mini-css-extract-plugin": "^0.9.0",
     "monaco-editor": "^0.56.0",
     "patch-package": "^6.2.2",
-    "playwright": "^1.62.1",
+    "playwright": "1.63.0",
     "postcss": "^7.0.32",
     "postcss-loader": "^3.0.0",
     "postcss-rem-to-pixel": "^4.1.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  retries: 0,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  // Browser launch + extension loading happens per-test in e2e/fixtures.ts instead.
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1144,6 +1144,13 @@
     consola "^2.15.0"
     node-fetch "^2.6.1"
 
+"@playwright/test@1.63.0":
+  version "1.63.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.63.0.tgz#808020c46e8b6b91f9d628cd0ebcbb32bdfd8b6c"
+  integrity sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==
+  dependencies:
+    playwright "1.63.0"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -5027,11 +5034,6 @@ fsevents@2.2.1:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.2.1.tgz#1fb02ded2036a8ac288d507a65962bd87b97628d"
   integrity sha512-bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==
 
-fsevents@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
-  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
-
 fsevents@^1.2.7:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.13.tgz#f325cb0455592428bcf11b383370ef70e3bfcc38"
@@ -8149,19 +8151,17 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright-core@1.62.1:
-  version "1.62.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.62.1.tgz#120f67a19181bfd183c60fa903c0d99330b56785"
-  integrity sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==
+playwright-core@1.63.0:
+  version "1.63.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.63.0.tgz#e57665bc32846c213ac39a1e4d5bc6228e76b376"
+  integrity sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==
 
-playwright@^1.62.1:
-  version "1.62.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.62.1.tgz#8447b6755e8aec85a3cb7207c823e3ed2fc66700"
-  integrity sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==
+playwright@1.63.0:
+  version "1.63.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.63.0.tgz#99b56f9f69b1b70c44f00bf84b2fe52348ae2511"
+  integrity sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==
   dependencies:
-    playwright-core "1.62.1"
-  optionalDependencies:
-    fsevents "2.3.2"
+    playwright-core "1.63.0"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
## Summary
- Adds a Playwright e2e harness that loads the built extension via CDP (`Extensions.loadUnpacked`), mirroring the existing `scripts/launch-chrome.mjs` approach since Chrome 137+ removed `--load-extension`.
- `e2e/smoke.spec.ts`: verifies the inject-css reveal path completes (guards the load-white-flash bug) and that the popup mounts.
- `e2e/open-in-current-tab.spec.ts`: verifies clicking "Open Stylebot" in the popup actually opens the editor in the correct tab (guards the won't-open bug cluster) — opens the popup in the background via CDP so it doesn't steal tab focus.
- `yarn test:e2e` builds then runs the suite; `--headed`/`--debug` work for watching it live; every run captures a Playwright trace viewable via `npx playwright show-report`.

## Test plan
- [x] `yarn test:e2e` passes locally
- [x] Stress-ran both specs 15-20x each to rule out flakiness (found and fixed two real races: the extension's onInstalled help tab stealing focus, and an unfiltered `waitForEvent('page')` occasionally grabbing that help tab instead of the popup)
- [x] Verified `--headed` and `--debug` correctly launch a visible browser
- [x] Verified the fixture's error message when `dist/` is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)