### PR TITLE
Localize readability dock menus, rename Stylebot Options to Options

### DIFF
--- a/src/_locales/de.config
+++ b/src/_locales/de.config
@@ -281,6 +281,47 @@ Breite verringern
 @increase_width
 Breite erhöhen
 
+@reset
+Zurücksetzen
+
+@remove
+Entfernen
+
+@modify_shortcut
+Tastenkombination ändern
+
+@set_shortcut
+Tastenkombination festlegen
+
+@readability_shortcut
+Tastenkombination für Lesbarkeit
+
+@readability_shortcut_description
+Lesbarkeit für Artikel auf einer Website umschalten
+
+@record_shortcut
+Tastenkombination aufzeichnen
+
+@change_shortcut
+Ändern…
+
+@press_key_to_finish
+Taste drücken zum Abschließen · Esc
+
+@esc_keeps
+behält
+
+@esc_cancels
+bricht ab
+
+@dismiss
+Schließen
+
+@reading_settings
+Leseeinstellungen
+
+@turn_off_readability_for_domain
+Lesbarkeit für $domain$ deaktivieren
 #==== Grayscale ====
 
 @grayscale

--- a/src/_locales/en.config
+++ b/src/_locales/en.config
@@ -278,6 +278,48 @@ Decrease Width
 @increase_width
 Increase Width
 
+@reset
+Reset
+
+@remove
+Remove
+
+@modify_shortcut
+Modify shortcut
+
+@set_shortcut
+Set shortcut
+
+@readability_shortcut
+Readability shortcut
+
+@readability_shortcut_description
+Toggle readability for articles on a site
+
+@record_shortcut
+Record shortcut
+
+@change_shortcut
+Change…
+
+@press_key_to_finish
+Press a key to finish · Esc
+
+@esc_keeps
+keeps
+
+@esc_cancels
+cancels
+
+@dismiss
+Dismiss
+
+@reading_settings
+Reading settings
+
+@turn_off_readability_for_domain
+Turn off readability for $domain$
+
 #==== Grayscale ====
 
 @grayscale

--- a/src/_locales/en_GB.config
+++ b/src/_locales/en_GB.config
@@ -281,6 +281,47 @@ Decrease Width
 @increase_width
 Increase Width
 
+@reset
+Reset
+
+@remove
+Remove
+
+@modify_shortcut
+Modify shortcut
+
+@set_shortcut
+Set shortcut
+
+@readability_shortcut
+Readability shortcut
+
+@readability_shortcut_description
+Toggle readability for articles on a site
+
+@record_shortcut
+Record shortcut
+
+@change_shortcut
+Change…
+
+@press_key_to_finish
+Press a key to finish · Esc
+
+@esc_keeps
+keeps
+
+@esc_cancels
+cancels
+
+@dismiss
+Dismiss
+
+@reading_settings
+Reading settings
+
+@turn_off_readability_for_domain
+Turn off readability for $domain$
 #==== Grayscale ====
 
 @grayscale

--- a/src/_locales/en_US.config
+++ b/src/_locales/en_US.config
@@ -281,6 +281,47 @@ Decrease Width
 @increase_width
 Increase Width
 
+@reset
+Reset
+
+@remove
+Remove
+
+@modify_shortcut
+Modify shortcut
+
+@set_shortcut
+Set shortcut
+
+@readability_shortcut
+Readability shortcut
+
+@readability_shortcut_description
+Toggle readability for articles on a site
+
+@record_shortcut
+Record shortcut
+
+@change_shortcut
+Change…
+
+@press_key_to_finish
+Press a key to finish · Esc
+
+@esc_keeps
+keeps
+
+@esc_cancels
+cancels
+
+@dismiss
+Dismiss
+
+@reading_settings
+Reading settings
+
+@turn_off_readability_for_domain
+Turn off readability for $domain$
 #==== Grayscale ====
 
 @grayscale

--- a/src/_locales/es.config
+++ b/src/_locales/es.config
@@ -281,6 +281,47 @@ Disminuir ancho
 @increase_width
 Aumentar ancho 
 
+@reset
+Restablecer
+
+@remove
+Eliminar
+
+@modify_shortcut
+Modificar atajo
+
+@set_shortcut
+Configurar atajo
+
+@readability_shortcut
+Atajo de legibilidad
+
+@readability_shortcut_description
+Alternar legibilidad para artículos de un sitio
+
+@record_shortcut
+Grabar atajo
+
+@change_shortcut
+Cambiar…
+
+@press_key_to_finish
+Presiona una tecla para terminar · Esc
+
+@esc_keeps
+conserva
+
+@esc_cancels
+cancela
+
+@dismiss
+Descartar
+
+@reading_settings
+Ajustes de lectura
+
+@turn_off_readability_for_domain
+Desactivar legibilidad para $domain$
 #==== Grayscale ====
 
 @grayscale

--- a/src/_locales/fr.config
+++ b/src/_locales/fr.config
@@ -281,6 +281,47 @@ Diminuer la largeur
 @increase_width
 Augmenter la largeur
 
+@reset
+Réinitialiser
+
+@remove
+Supprimer
+
+@modify_shortcut
+Modifier le raccourci
+
+@set_shortcut
+Définir un raccourci
+
+@readability_shortcut
+Raccourci de lisibilité
+
+@readability_shortcut_description
+Activer/désactiver la lisibilité pour les articles d'un site
+
+@record_shortcut
+Enregistrer un raccourci
+
+@change_shortcut
+Modifier…
+
+@press_key_to_finish
+Appuyez sur une touche pour terminer · Échap
+
+@esc_keeps
+conserve
+
+@esc_cancels
+annule
+
+@dismiss
+Ignorer
+
+@reading_settings
+Paramètres de lecture
+
+@turn_off_readability_for_domain
+Désactiver la lisibilité pour $domain$
 #==== Grayscale ====
 
 @grayscale

--- a/src/_locales/it.config
+++ b/src/_locales/it.config
@@ -281,6 +281,47 @@ Diminuisci larghezza
 @increase_width
 Aumenta larghezza
 
+@reset
+Ripristina
+
+@remove
+Rimuovi
+
+@modify_shortcut
+Modifica scorciatoia
+
+@set_shortcut
+Imposta scorciatoia
+
+@readability_shortcut
+Scorciatoia leggibilità
+
+@readability_shortcut_description
+Attiva/disattiva la leggibilità per gli articoli di un sito
+
+@record_shortcut
+Registra scorciatoia
+
+@change_shortcut
+Modifica…
+
+@press_key_to_finish
+Premi un tasto per terminare · Esc
+
+@esc_keeps
+mantiene
+
+@esc_cancels
+annulla
+
+@dismiss
+Ignora
+
+@reading_settings
+Impostazioni di lettura
+
+@turn_off_readability_for_domain
+Disattiva la leggibilità per $domain$
 #==== Grayscale ====
 
 @grayscale

--- a/src/_locales/ja.config
+++ b/src/_locales/ja.config
@@ -284,6 +284,47 @@ CSSを適用して選択した要素を表示/非表示
 @increase_width
 幅を広げる
 
+@reset
+リセット
+
+@remove
+削除
+
+@modify_shortcut
+ショートカットを変更
+
+@set_shortcut
+ショートカットを設定
+
+@readability_shortcut
+読みやすさ優先化のショートカット
+
+@readability_shortcut_description
+サイトの記事の読みやすさ優先化を切り替える
+
+@record_shortcut
+ショートカットを記録
+
+@change_shortcut
+変更…
+
+@press_key_to_finish
+キーを押して完了 · Esc
+
+@esc_keeps
+保持
+
+@esc_cancels
+キャンセル
+
+@dismiss
+閉じる
+
+@reading_settings
+読書設定
+
+@turn_off_readability_for_domain
+$domain$ の読みやすさ優先化をオフにする
 #==== Grayscale ====
 
 @grayscale

--- a/src/_locales/ko.config
+++ b/src/_locales/ko.config
@@ -281,6 +281,47 @@ CSS를 적용해 선택한 요소를 표시하거나 숨기기
 @increase_width
 너비 늘리기
 
+@reset
+재설정
+
+@remove
+제거
+
+@modify_shortcut
+단축키 수정
+
+@set_shortcut
+단축키 설정
+
+@readability_shortcut
+가독성 모드 단축키
+
+@readability_shortcut_description
+사이트의 기사에 가독성 모드 전환
+
+@record_shortcut
+단축키 기록
+
+@change_shortcut
+변경…
+
+@press_key_to_finish
+완료하려면 키를 누르세요 · Esc
+
+@esc_keeps
+유지
+
+@esc_cancels
+취소
+
+@dismiss
+닫기
+
+@reading_settings
+읽기 설정
+
+@turn_off_readability_for_domain
+$domain$에 대한 가독성 모드 끄기
 #==== Grayscale ====
 
 @grayscale

--- a/src/_locales/pt_BR.config
+++ b/src/_locales/pt_BR.config
@@ -282,6 +282,47 @@ Diminuir comprimento
 @increase_width
 Aumentar comprimento
 
+@reset
+Redefinir
+
+@remove
+Remover
+
+@modify_shortcut
+Modificar atalho
+
+@set_shortcut
+Definir atalho
+
+@readability_shortcut
+Atalho do modo legível
+
+@readability_shortcut_description
+Ativar/desativar o modo legível para artigos de um site
+
+@record_shortcut
+Gravar atalho
+
+@change_shortcut
+Alterar…
+
+@press_key_to_finish
+Pressione uma tecla para concluir · Esc
+
+@esc_keeps
+mantém
+
+@esc_cancels
+cancela
+
+@dismiss
+Dispensar
+
+@reading_settings
+Configurações de leitura
+
+@turn_off_readability_for_domain
+Desativar o modo legível para $domain$
 #==== Grayscale ====
 
 @grayscale

--- a/src/_locales/pt_PT.config
+++ b/src/_locales/pt_PT.config
@@ -282,6 +282,47 @@ Diminuir comprimento
 @increase_width
 Aumentar comprimento
 
+@reset
+Redefinir
+
+@remove
+Remover
+
+@modify_shortcut
+Modificar atalho
+
+@set_shortcut
+Definir atalho
+
+@readability_shortcut
+Atalho do modo legível
+
+@readability_shortcut_description
+Ativar/desativar o modo legível para artigos de um site
+
+@record_shortcut
+Gravar atalho
+
+@change_shortcut
+Alterar…
+
+@press_key_to_finish
+Pressione uma tecla para concluir · Esc
+
+@esc_keeps
+mantém
+
+@esc_cancels
+cancela
+
+@dismiss
+Dispensar
+
+@reading_settings
+Configurações de leitura
+
+@turn_off_readability_for_domain
+Desativar o modo legível para $domain$
 #==== Grayscale ====
 
 @grayscale

--- a/src/_locales/ro.config
+++ b/src/_locales/ro.config
@@ -281,6 +281,47 @@ Micșorează lungimea
 @increase_width
 Mărește lungimea
 
+@reset
+Resetează
+
+@remove
+Elimină
+
+@modify_shortcut
+Modifică scurtătura
+
+@set_shortcut
+Setează scurtătura
+
+@readability_shortcut
+Scurtătură pentru lizibilitate
+
+@readability_shortcut_description
+Comută modul de lizibilitate pentru articolele unui site
+
+@record_shortcut
+Înregistrează scurtătura
+
+@change_shortcut
+Schimbă…
+
+@press_key_to_finish
+Apasă o tastă pentru a termina · Esc
+
+@esc_keeps
+păstrează
+
+@esc_cancels
+anulează
+
+@dismiss
+Închide
+
+@reading_settings
+Setări de citire
+
+@turn_off_readability_for_domain
+Dezactivează lizibilitatea pentru $domain$
 #==== Grayscale ====
 
 @grayscale

--- a/src/_locales/ru.config
+++ b/src/_locales/ru.config
@@ -281,6 +281,47 @@
 @increase_width
 Увеличить ширину
 
+@reset
+Сбросить
+
+@remove
+Удалить
+
+@modify_shortcut
+Изменить сочетание клавиш
+
+@set_shortcut
+Задать сочетание клавиш
+
+@readability_shortcut
+Сочетание клавиш для удобочитаемости
+
+@readability_shortcut_description
+Переключить удобочитаемость для статей на сайте
+
+@record_shortcut
+Записать сочетание клавиш
+
+@change_shortcut
+Изменить…
+
+@press_key_to_finish
+Нажмите клавишу для завершения · Esc
+
+@esc_keeps
+сохраняет
+
+@esc_cancels
+отменяет
+
+@dismiss
+Закрыть
+
+@reading_settings
+Настройки чтения
+
+@turn_off_readability_for_domain
+Отключить удобочитаемость для $domain$
 #==== Grayscale ====
 
 @grayscale

--- a/src/_locales/zh_CN.config
+++ b/src/_locales/zh_CN.config
@@ -281,6 +281,47 @@
 @increase_width
 增加宽度
 
+@reset
+重置
+
+@remove
+移除
+
+@modify_shortcut
+修改快捷键
+
+@set_shortcut
+设置快捷键
+
+@readability_shortcut
+简阅快捷键
+
+@readability_shortcut_description
+切换网站文章的简阅模式
+
+@record_shortcut
+录制快捷键
+
+@change_shortcut
+更改…
+
+@press_key_to_finish
+按键完成 · Esc
+
+@esc_keeps
+保留
+
+@esc_cancels
+取消
+
+@dismiss
+关闭
+
+@reading_settings
+阅读设置
+
+@turn_off_readability_for_domain
+关闭 $domain$ 的简阅模式
 #==== Grayscale ====
 
 @grayscale

--- a/src/_locales/zh_TW.config
+++ b/src/_locales/zh_TW.config
@@ -281,6 +281,47 @@
 @increase_width
 增加寬度
 
+@reset
+重設
+
+@remove
+移除
+
+@modify_shortcut
+修改快捷鍵
+
+@set_shortcut
+設定快捷鍵
+
+@readability_shortcut
+簡閱快捷鍵
+
+@readability_shortcut_description
+切換網站文章的簡閱模式
+
+@record_shortcut
+錄製快捷鍵
+
+@change_shortcut
+變更…
+
+@press_key_to_finish
+按鍵完成 · Esc
+
+@esc_keeps
+保留
+
+@esc_cancels
+取消
+
+@dismiss
+關閉
+
+@reading_settings
+閱讀設定
+
+@turn_off_readability_for_domain
+關閉 $domain$ 的簡閱模式
 #==== Grayscale ====
 
 @grayscale

--- a/src/readability/components/dock/MoreMenu.vue
+++ b/src/readability/components/dock/MoreMenu.vue
@@ -7,15 +7,15 @@
     </button>
     <button class="item" @click="openOptions">
       <icon-options />
-      Stylebot Options
+      {{ t('view_options') }}
     </button>
     <button class="item" @click="reportIssue">
       <icon-flag />
-      Report an issue
+      {{ t('report_an_issue') }}
     </button>
     <button class="item" @click="donate">
       <icon-coffee />
-      Donate
+      {{ t('donate') }}
     </button>
   </menu-box>
 </template>
@@ -55,7 +55,7 @@ export default Vue.extend({
     },
 
     shortcutLabel(): string {
-      return this.shortcutValue ? 'Modify shortcut' : 'Set shortcut';
+      return this.shortcutValue ? this.t('modify_shortcut') : this.t('set_shortcut');
     },
   },
 

--- a/src/readability/components/dock/SettingsMenu.vue
+++ b/src/readability/components/dock/SettingsMenu.vue
@@ -11,7 +11,7 @@
     <justify-toggle :justify="justify" @pick="pickJustify" />
 
     <div class="reset-row">
-      <button class="reset" @click="reset">Reset</button>
+      <button class="reset" @click="reset">{{ t('reset') }}</button>
     </div>
   </menu-box>
 </template>

--- a/src/readability/components/dock/ShortcutMenu.vue
+++ b/src/readability/components/dock/ShortcutMenu.vue
@@ -7,45 +7,45 @@
             <shortcut-kbd v-if="liveModifiers" :value="liveModifiers" />
             <span class="placeholder">_</span>
           </span>
-          <button type="button" class="cancel" @click="cancelRecording">Cancel</button>
+          <button type="button" class="cancel" @click="cancelRecording">{{ t('cancel') }}</button>
         </div>
         <p class="helper">
-          Press a key to finish · Esc
+          {{ t('press_key_to_finish') }}
           <template v-if="hasValue">
-            keeps <span class="chip chip-inline"><shortcut-kbd :value="value" /></span>
+            {{ t('esc_keeps') }} <span class="chip chip-inline"><shortcut-kbd :value="value" /></span>
           </template>
-          <template v-else>cancels</template>
+          <template v-else>{{ t('esc_cancels') }}</template>
         </p>
       </div>
 
       <div v-else-if="hasValue" class="content">
         <div class="header-row">
-          <div class="title">Readability shortcut</div>
+          <div class="title">{{ t('readability_shortcut') }}</div>
           <shortcut-chip :value="value" />
         </div>
-        <p class="desc">Toggle readability for articles on a site</p>
+        <p class="desc">{{ t('readability_shortcut_description') }}</p>
         <div class="divider" />
-        <button type="button" class="row" @click="startRecording">Change…</button>
-        <button type="button" class="row danger" @click="remove">Remove</button>
+        <button type="button" class="row" @click="startRecording">{{ t('change_shortcut') }}</button>
+        <button type="button" class="row danger" @click="remove">{{ t('remove') }}</button>
       </div>
 
       <div v-else class="content">
         <div class="header-row">
-          <div class="title">Readability shortcut</div>
+          <div class="title">{{ t('readability_shortcut') }}</div>
           <button
             v-if="dismissible"
             type="button"
             class="dismiss"
-            aria-label="Dismiss"
+            :aria-label="t('dismiss')"
             @click="dismiss"
           >
             <icon-x />
           </button>
         </div>
-        <p class="desc">Toggle readability for articles on a site</p>
+        <p class="desc">{{ t('readability_shortcut_description') }}</p>
         <button type="button" class="record-btn" @click="startRecording">
           <icon-keyboard />
-          Record shortcut
+          {{ t('record_shortcut') }}
         </button>
       </div>
     </menu-box>

--- a/src/readability/components/dock/TheReaderDock.vue
+++ b/src/readability/components/dock/TheReaderDock.vue
@@ -13,7 +13,7 @@
         :active="activeMenu === 'settings'"
         :disabled="recording"
         @click="toggleMenu('settings')"
-        @hover="showTip($event, 'Reading settings')"
+        @hover="showTip($event, t('reading_settings'))"
         @unhover="hideTip"
       />
 
@@ -157,7 +157,7 @@ export default Vue.extend({
     },
 
     closeTipText(): string {
-      return `Turn off readability for ${document.domain}`;
+      return this.t('turn_off_readability_for_domain', [document.domain]);
     },
 
     recording(): boolean {

--- a/src/readability/components/dock/__tests__/MoreMenu.test.ts
+++ b/src/readability/components/dock/__tests__/MoreMenu.test.ts
@@ -14,15 +14,15 @@ describe('MoreMenu.vue', () => {
     shortcutStore.state.commands = { readability: '', style: '', stylebot: '', grayscale: '' };
   });
 
-  it('shows "Set shortcut" with no chip when unset', () => {
+  it('shows "set_shortcut" with no chip when unset', () => {
     const wrapper = mount(MoreMenu);
 
-    expect(wrapper.text()).toContain('Set shortcut');
-    expect(wrapper.text()).not.toContain('Modify shortcut');
+    expect(wrapper.text()).toContain('set_shortcut');
+    expect(wrapper.text()).not.toContain('modify_shortcut');
     expect(wrapper.find('.chip').exists()).toBe(false);
   });
 
-  it('shows "Modify shortcut" with the current combo chip when set', () => {
+  it('shows "modify_shortcut" with the current combo chip when set', () => {
     shortcutStore.state.commands = {
       readability: 'alt+shift+r',
       style: '',
@@ -32,7 +32,7 @@ describe('MoreMenu.vue', () => {
 
     const wrapper = mount(MoreMenu);
 
-    expect(wrapper.text()).toContain('Modify shortcut');
+    expect(wrapper.text()).toContain('modify_shortcut');
     expect(wrapper.find('.chip').exists()).toBe(true);
   });
 
@@ -47,7 +47,7 @@ describe('MoreMenu.vue', () => {
   it('emits close (not open-shortcut) for the other items', async () => {
     const wrapper = mount(MoreMenu);
 
-    await wrapper.findAll('.item').at(1).trigger('click'); // Stylebot Options
+    await wrapper.findAll('.item').at(1).trigger('click'); // Options
 
     expect(wrapper.emitted('close')).toHaveLength(1);
     expect(wrapper.emitted('open-shortcut')).toBeUndefined();

--- a/src/readability/components/dock/__tests__/ShortcutMenu.test.ts
+++ b/src/readability/components/dock/__tests__/ShortcutMenu.test.ts
@@ -39,15 +39,15 @@ describe('ShortcutMenu.vue', () => {
   it('shows the invite to record a shortcut when unset', () => {
     const wrapper = mountMenu('');
 
-    expect(wrapper.text()).toContain('Record shortcut');
-    expect(wrapper.text()).not.toContain('Change…');
+    expect(wrapper.text()).toContain('record_shortcut');
+    expect(wrapper.text()).not.toContain('change_shortcut');
   });
 
   it('shows the current shortcut with Change/Remove when set', () => {
     const wrapper = mountMenu('alt+shift+r');
 
-    expect(wrapper.text()).toContain('Change…');
-    expect(wrapper.text()).toContain('Remove');
+    expect(wrapper.text()).toContain('change_shortcut');
+    expect(wrapper.text()).toContain('remove');
   });
 
   it('clicking "Record a shortcut" starts recording', async () => {
@@ -56,13 +56,13 @@ describe('ShortcutMenu.vue', () => {
     await wrapper.find('.record-btn').trigger('click');
 
     expect(shortcutStore.state.recording).toBe(true);
-    expect(wrapper.text()).toContain('Press a key to finish');
+    expect(wrapper.text()).toContain('press_key_to_finish');
   });
 
   it('capturing a key combo persists it and stops recording', async () => {
     const wrapper = mountMenu('alt+shift+r');
 
-    await wrapper.findAll('.row').at(0).trigger('click'); // "Change…"
+    await wrapper.findAll('.row').at(0).trigger('click'); // "change_shortcut"
     expect(shortcutStore.state.recording).toBe(true);
 
     wrapper.element.dispatchEvent(

--- a/src/readability/lifecycle/mount-reader.ts
+++ b/src/readability/lifecycle/mount-reader.ts
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+import { t } from '@stylebot/i18n';
 import { hasReaderableContent } from '../eligibility/has-readerable-content';
 
 import App from '../components/App.vue';
@@ -7,6 +8,12 @@ import { getReadabilityArticle } from './get-readability-article';
 
 import { ReadabilityArticle } from '@stylebot/types';
 import { cacheDocument } from './document-cache';
+
+Vue.mixin({
+  methods: {
+    t,
+  },
+});
 
 /**
  * Fetches the reader's compiled stylesheet and injects it into the shadow root.


### PR DESCRIPTION
## Summary
- The reader dock's settings/shortcut/more menus hardcoded their English copy directly in Vue templates instead of going through the extension's i18n system (`t()` / `chrome.i18n.getMessage`).
- Routes all of those strings through the existing i18n pipeline, matching how the editor and popup already work, and adds the new keys with translations across all 14 supported locales.
- Renames "Stylebot Options" to "Options" in the reader dock's More menu, reusing the `view_options` key (already "Options" elsewhere, e.g. editor/popup/context menu).

## Test plan
- [x] `jest` — full suite passes (226 tests), including updated `MoreMenu.test.ts` / `ShortcutMenu.test.ts` assertions
- [x] `tsc --noEmit` — clean
- [x] `eslint --ext .js,.ts,.vue src/readability` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)