### PR TITLE
Fix domain toggle not looking disabled when Readability is on

### DIFF
--- a/src/popup/components/ToggleSwitch.vue
+++ b/src/popup/components/ToggleSwitch.vue
@@ -102,11 +102,11 @@ input {
   transition: transform 0.15s ease;
 }
 
-input:checked ~ .track {
+input:checked:not(:disabled) ~ .track {
   background: var(--popup-accent);
 }
 
-input:checked ~ .track .thumb {
+input:checked:not(:disabled) ~ .track .thumb {
   background: var(--thumb-on);
 }
 


### PR DESCRIPTION
## Summary
- The domain toggle in the popup should look disabled when Readability mode is active on the page, since styles can't be toggled in that state.
- The `disabled` state was already wired correctly end-to-end (`App.vue` → `Style.vue` → `ToggleSwitch.vue`), so the toggle was functionally non-interactive — but visually it still rendered fully blue/"on", indistinguishable from an active toggle.
- Root cause: in `ToggleSwitch.vue`, the checked-state color rule (`input:checked ~ .track`, specificity 0,2,1) had higher CSS specificity than the disabled-state rule (`.disabled .track`, specificity 0,2,0), so a checked+disabled toggle rendered blue instead of gray.
- Fix: scope the checked-color rules to `input:checked:not(:disabled)` so the disabled gray styling applies whenever the input is disabled, regardless of checked state.

## Test plan
- [x] `npx jest src/popup` — all 32 tests pass
- [x] Load the extension, enable Readability on a readerable page, confirm the domain toggle in the popup now renders gray/disabled instead of blue
- [x] Confirm clicking the domain toggle while Readability is on remains a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)