### PR TITLE
Run e2e tests in CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,55 @@
+name: e2e
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node from .nvmrc
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Use cached node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: nodeModules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            nodeModules-
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install Playwright Chrome
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chrome
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chrome
+
+      - name: Run e2e tests
+        run: yarn test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/e2e/open-in-current-tab.spec.ts
+++ b/e2e/open-in-current-tab.spec.ts
@@ -16,7 +16,9 @@ test('opening Stylebot from the popup opens the editor in the current tab', asyn
   // The popup calls window.close() right after sending the toggle message, which
   // races a plain .click()'s post-click stability wait — dispatch instead.
   const popup = await openPopup();
-  await popup.locator('.open-stylebot').dispatchEvent('click');
+  await popup
+    .getByRole('button', { name: /^Style this page/ })
+    .dispatchEvent('click');
 
   // The host is deliberately 0x0 (see init-editor.ts) — assert presence, not visibility.
   await expect(page.locator('#stylebot')).toBeAttached();

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -9,9 +9,15 @@ test('reveals the page after the content script runs', async ({ context }) => {
   await expect(page.locator('#stylebot-hide-page')).toHaveCount(0);
 });
 
-test('popup mounts and renders the open-editor toggle', async ({ context, extensionId }) => {
-  const popup = await context.newPage();
-  await popup.goto(`chrome-extension://${extensionId}/popup/index.html`);
+test('popup mounts and renders the open-editor toggle', async ({ context, openPopup }) => {
+  // A real page must be the active tab first — otherwise the popup's own
+  // chrome-extension:// tab becomes "the current tab" and it renders the
+  // restricted-page state instead of the toggle.
+  const page = await context.newPage();
+  await page.goto('https://example.com');
+  await page.bringToFront();
+
+  const popup = await openPopup();
 
   // Proves the popup's Vue app mounts without throwing — the direct symptom
   // of the "won't open" bug cluster is a blank or broken popup here.

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -15,5 +15,7 @@ test('popup mounts and renders the open-editor toggle', async ({ context, extens
 
   // Proves the popup's Vue app mounts without throwing — the direct symptom
   // of the "won't open" bug cluster is a blank or broken popup here.
-  await expect(popup.locator('.open-stylebot')).toBeVisible();
+  await expect(
+    popup.getByRole('button', { name: /^Style this page/ })
+  ).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/e2e.yml`, a new CI workflow that builds the extension, installs a real Chrome channel for Playwright (cached between runs), and runs `yarn test:e2e` on push/PR. Mirrors the existing `build.yml`/`validation.yml` steps (checkout, Node from `.nvmrc`, cached `node_modules`, `yarn install --frozen-lockfile`).
- The Playwright HTML report is uploaded as a workflow artifact (`if: !cancelled()`, 14-day retention) so failures are debuggable via `npx playwright show-report` after download. Kept it as an artifact rather than publishing to `gh-pages`, since that branch already serves the stylebot.dev marketing site and test reports shouldn't live there.
- Fixes `e2e/smoke.spec.ts` and `e2e/open-in-current-tab.spec.ts`, which targeted a `.open-stylebot` class removed by the popup redesign (#867) before the e2e harness (#868) landed on top of it — both specs were failing against current `main`. Switched to role-based locators (`getByRole('button', { name: /^Style this page/ })`) matching the actual `<button>` markup.

## Test plan
- [x] `yarn test:e2e` passes locally (3/3)
- [x] Stress-ran the suite 5x locally after the selector fix, no flakes
- [x] `yarn lint` / `yarn typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)