### PR TITLE
Fix Readability toggle silently overwriting the global default editing mode

### DIFF
--- a/src/editor/store/__tests__/actions.test.ts
+++ b/src/editor/store/__tests__/actions.test.ts
@@ -138,10 +138,7 @@ describe('actions', () => {
     });
 
     it('does nothing to the cache when nothing is cached yet', () => {
-      actions.applyReadability(
-        { commit: mockCommit, state: mockState, dispatch: mockDispatch },
-        true
-      );
+      actions.applyReadability({ commit: mockCommit, state: mockState }, true);
 
       expect(readCache()).toBeNull();
     });
@@ -152,10 +149,7 @@ describe('actions', () => {
         readability: false,
       });
 
-      actions.applyReadability(
-        { commit: mockCommit, state: mockState, dispatch: mockDispatch },
-        true
-      );
+      actions.applyReadability({ commit: mockCommit, state: mockState }, true);
 
       expect(readCache()).toEqual({
         styles: [{ url: mockState.url, css: 'a { color: blue; }', enabled: true }],
@@ -165,22 +159,23 @@ describe('actions', () => {
       expect(chromeUtils.setReadability).toBeCalledWith(mockState.url, true);
     });
 
-    it('switches out of basic/code mode since editing page CSS has no effect there', () => {
-      actions.applyReadability(
-        { commit: mockCommit, state: mockState, dispatch: mockDispatch },
-        true
-      );
+    it('switches out of basic/code mode since editing page CSS has no effect there, without persisting the mode change', () => {
+      actions.applyReadability({ commit: mockCommit, state: mockState }, true);
 
-      expect(mockDispatch).toBeCalledWith('setMode', 'magic');
+      expect(mockCommit).toBeCalledWith('setOptions', {
+        ...mockState.options,
+        mode: 'magic',
+      });
+      expect(chromeUtils.setOption).not.toBeCalledWith('mode', 'magic');
     });
 
     it('leaves the mode alone when turning readability off', () => {
-      actions.applyReadability(
-        { commit: mockCommit, state: mockState, dispatch: mockDispatch },
-        false
-      );
+      actions.applyReadability({ commit: mockCommit, state: mockState }, false);
 
-      expect(mockDispatch).not.toBeCalledWith('setMode', 'magic');
+      expect(mockCommit).not.toBeCalledWith(
+        'setOptions',
+        expect.objectContaining({ mode: 'magic' })
+      );
     });
 
     it('leaves the mode alone when already in magic mode', () => {
@@ -188,12 +183,14 @@ describe('actions', () => {
         {
           commit: mockCommit,
           state: { ...mockState, options: { ...mockState.options, mode: 'magic' } },
-          dispatch: mockDispatch,
         },
         true
       );
 
-      expect(mockDispatch).not.toBeCalledWith('setMode', 'magic');
+      expect(mockCommit).not.toBeCalledWith(
+        'setOptions',
+        expect.objectContaining({ mode: 'magic' })
+      );
     });
   });
 

--- a/src/editor/store/actions.ts
+++ b/src/editor/store/actions.ts
@@ -238,11 +238,7 @@ export default {
   },
 
   applyReadability(
-    {
-      state,
-      commit,
-      dispatch,
-    }: { state: State; commit: Commit; dispatch: Dispatch },
+    { state, commit }: { state: State; commit: Commit },
     value: boolean
   ): void {
     if (value) {
@@ -252,9 +248,11 @@ export default {
     }
 
     // Editing page CSS has no effect while readability is running — its DOM
-    // is detached from the document, not just hidden.
+    // is detached from the document, not just hidden. Switch the panel to
+    // Magic locally without persisting over the user's global mode
+    // preference (mirrors openStylebot's readabilityActive handling above).
     if (value && ['basic', 'code'].includes(state.options.mode)) {
-      dispatch('setMode', 'magic');
+      commit('setOptions', { ...state.options, mode: 'magic' });
     }
 
     commit('setReadability', value);


### PR DESCRIPTION
## Summary
- `applyReadability` auto-switched out of Basic/Code mode into Magic mode when Readability/Reader mode was enabled, but it did so via `dispatch('setMode', 'magic')`, which persists the mode change to the global `chrome.storage.local` options.
- Since `mode` is a single global setting (not per-site), enabling Reader mode on any one page silently overwrote the user's editing-mode preference for every site, permanently, with no way to revert other than manually switching back.
- Fixed by switching the panel locally via `commit('setOptions', ...)` instead, mirroring the non-persisting pattern `openStylebot` already uses for the same "show Magic while readability is active" case.

## Test plan
- [x] Updated `applyReadability` unit tests to assert the local-only `commit('setOptions', ...)` call and that `setOption('mode', 'magic')` is never invoked
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [x] `npx jest` — 224/224 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)