### PR TITLE
Rename TextBlock to SText to match SButton

### DIFF
--- a/src/components/ConfirmDialog.vue
+++ b/src/components/ConfirmDialog.vue
@@ -9,7 +9,7 @@
       aria-describedby="confirm-dialog-message"
     >
       <heading id="confirm-dialog-title" as="h2" size="md">{{ title }}</heading>
-      <text-block id="confirm-dialog-message" size="caption" variant="muted" class="message">{{ message }}</text-block>
+      <s-text id="confirm-dialog-message" size="caption" variant="muted" class="message">{{ message }}</s-text>
 
       <div class="actions">
         <s-button ref="cancelButton" variant="ghost" @click="$emit('cancel')">
@@ -26,7 +26,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { Heading, TextBlock, SButton } from '@stylebot/components';
+import { Heading, SText, SButton } from '@stylebot/components';
 
 export default Vue.extend({
   name: 'ConfirmDialog',
@@ -34,7 +34,7 @@ export default Vue.extend({
   components: {
     SButton,
     Heading,
-    TextBlock,
+    SText,
   },
 
   props: {

--- a/src/components/SText.vue
+++ b/src/components/SText.vue
@@ -11,9 +11,7 @@ type Size = 'body' | 'caption';
 type Variant = 'muted' | 'default';
 
 export default Vue.extend({
-  // Named TextBlock, not Text — Vue 2 treats <text> as a reserved SVG tag,
-  // so a component registered/used as <text> silently renders as inert SVG.
-  name: 'TextBlock',
+  name: 'SText',
 
   props: {
     size: {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,5 @@
 export { default as Heading } from './Heading.vue';
-export { default as TextBlock } from './TextBlock.vue';
+export { default as SText } from './SText.vue';
 export { default as ShortcutChip } from './ShortcutChip.vue';
 export { default as ShortcutKbd } from './ShortcutKbd.vue';
 export { default as ShortcutRecorderField } from './ShortcutRecorderField.vue';

--- a/src/options/components/TheStylesTab.vue
+++ b/src/options/components/TheStylesTab.vue
@@ -3,10 +3,10 @@
     <div class="header">
       <div class="title-block">
         <heading as="h1">{{ t('styles_options') }}</heading>
-        <text-block variant="muted" class="subtitle">
+        <s-text variant="muted" class="subtitle">
           {{ t(totalCount === 1 ? 'sites_count_one' : 'sites_count_other', [String(totalCount)]) }} ·
           {{ t('enabled_count', [String(enabledCount)]) }}
-        </text-block>
+        </s-text>
       </div>
 
       <s-button @click="$emit('edit', '')">{{ t('add_a_style') }}</s-button>
@@ -57,7 +57,7 @@ import Vue from 'vue';
 import { compareAsc } from 'date-fns';
 
 import { Style } from '@stylebot/types';
-import { Heading, TextBlock, SButton, ConfirmDialog } from '@stylebot/components';
+import { Heading, SText, SButton, ConfirmDialog } from '@stylebot/components';
 
 import StyleListRow from './styles/StyleListRow.vue';
 import StylesBulkMenu from './styles/StylesBulkMenu.vue';
@@ -67,7 +67,7 @@ export default Vue.extend({
 
   components: {
     Heading,
-    TextBlock,
+    SText,
     SButton,
     ConfirmDialog,
     StyleListRow,

--- a/src/options/components/TheSyncTab.vue
+++ b/src/options/components/TheSyncTab.vue
@@ -10,14 +10,14 @@
 
     <div>
       <heading as="h1">{{ t('sync_options') }}</heading>
-      <text-block variant="muted" class="description">Keep your styles on every computer you sign in to.</text-block>
+      <s-text variant="muted" class="description">Keep your styles on every computer you sign in to.</s-text>
 
       <the-google-drive-sync />
     </div>
 
     <div class="section">
       <heading as="h2">{{ t('backup') }}</heading>
-      <text-block variant="muted" class="description">{{ t('backup_description') }}</text-block>
+      <s-text variant="muted" class="description">{{ t('backup_description') }}</s-text>
 
       <div class="buttons">
         <s-button @click="exportJson">{{ t('export') }}</s-button>
@@ -30,7 +30,7 @@
 <script lang="ts">
 import Vue from 'vue';
 
-import { Heading, TextBlock, SButton } from '@stylebot/components';
+import { Heading, SText, SButton } from '@stylebot/components';
 import TheGoogleDriveSync from './sync/TheGoogleDriveSync.vue';
 
 import { importStylesWithFilePicker, exportAsJSONFile } from '../utils';
@@ -40,7 +40,7 @@ export default Vue.extend({
 
   components: {
     Heading,
-    TextBlock,
+    SText,
     SButton,
     TheGoogleDriveSync,
   },

--- a/src/options/components/basics/TheContextMenu.vue
+++ b/src/options/components/basics/TheContextMenu.vue
@@ -2,14 +2,14 @@
   <div class="card">
     <toggle-switch size="lg" :value="contextMenu" @change="contextMenu = $event">
       <heading as="h2" size="sm">{{ t('right_click_menu') }}</heading>
-      <text-block size="caption" variant="muted" class="description">{{ t('right_click_menu_description') }}</text-block>
+      <s-text size="caption" variant="muted" class="description">{{ t('right_click_menu_description') }}</s-text>
     </toggle-switch>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
-import { ToggleSwitch, Heading, TextBlock } from '@stylebot/components';
+import { ToggleSwitch, Heading, SText } from '@stylebot/components';
 
 export default Vue.extend({
   name: 'TheContextMenu',
@@ -17,7 +17,7 @@ export default Vue.extend({
   components: {
     ToggleSwitch,
     Heading,
-    TextBlock,
+    SText,
   },
 
   computed: {

--- a/src/options/components/basics/TheFonts.vue
+++ b/src/options/components/basics/TheFonts.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <heading as="h2">{{ t('fonts') }}</heading>
-    <text-block variant="muted" class="description">{{ t('fonts_description') }}</text-block>
+    <s-text variant="muted" class="description">{{ t('fonts_description') }}</s-text>
 
     <div class="fonts-box" @click="focusInput">
       <span
@@ -44,7 +44,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { defaultOptions } from '@stylebot/settings';
-import { Heading, TextBlock } from '@stylebot/components';
+import { Heading, SText } from '@stylebot/components';
 import { IconX } from '@stylebot/icons';
 
 export default Vue.extend({
@@ -53,7 +53,7 @@ export default Vue.extend({
   components: {
     IconX,
     Heading,
-    TextBlock,
+    SText,
   },
 
   data(): { newFont: string } {

--- a/src/options/components/basics/TheKeyboardShortcuts.vue
+++ b/src/options/components/basics/TheKeyboardShortcuts.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <heading as="h2">{{ t('keyboard_shortcuts') }}</heading>
-    <text-block variant="muted" class="description">{{ t('keyboard_shortcuts_description') }}</text-block>
+    <s-text variant="muted" class="description">{{ t('keyboard_shortcuts_description') }}</s-text>
 
     <div class="rows">
       <shortcut-row :label="t('toggle_editor')">
@@ -26,7 +26,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { StylebotCommandName, StylebotCommands } from '@stylebot/types';
-import { ShortcutRecorderField, Heading, TextBlock } from '@stylebot/components';
+import { ShortcutRecorderField, Heading, SText } from '@stylebot/components';
 
 import ShortcutRow from './ShortcutRow.vue';
 
@@ -37,7 +37,7 @@ export default Vue.extend({
     ShortcutRow,
     ShortcutRecorderField,
     Heading,
-    TextBlock,
+    SText,
   },
 
   computed: {

--- a/src/options/components/styles/StyleListRow.vue
+++ b/src/options/components/styles/StyleListRow.vue
@@ -4,7 +4,7 @@
       <div class="domain" :class="{ disabled: !enabled }">{{ url }}</div>
     </toggle-switch>
 
-    <text-block size="caption" variant="muted" class="timestamp">{{ formattedTimestamp }}</text-block>
+    <s-text size="caption" variant="muted" class="timestamp">{{ formattedTimestamp }}</s-text>
 
     <s-button variant="ghost" @click="$emit('edit', url)">{{ t('edit') }}</s-button>
 
@@ -28,7 +28,7 @@
 import Vue from 'vue';
 import { formatDistanceToNow } from 'date-fns';
 
-import { ToggleSwitch, TextBlock, SButton, ConfirmDialog } from '@stylebot/components';
+import { ToggleSwitch, SText, SButton, ConfirmDialog } from '@stylebot/components';
 import StyleRowMenu from './StyleRowMenu.vue';
 
 export default Vue.extend({
@@ -36,7 +36,7 @@ export default Vue.extend({
 
   components: {
     ToggleSwitch,
-    TextBlock,
+    SText,
     SButton,
     ConfirmDialog,
     StyleRowMenu,

--- a/src/options/components/styles/TheStyleEditorPage.vue
+++ b/src/options/components/styles/TheStyleEditorPage.vue
@@ -36,10 +36,10 @@
     </div>
 
     <div class="editor-footer">
-      <text-block size="caption" variant="muted" class="stats">
+      <s-text size="caption" variant="muted" class="stats">
         {{ lineCountLabel }} · {{ ruleCountLabel }}
         <template v-if="savedLabel"> · {{ savedLabel }}</template>
-      </text-block>
+      </s-text>
 
       <s-button variant="ghost" :disabled="!isDirty" @click="$emit('back')">
         {{ t('discard_changes') }}
@@ -76,7 +76,7 @@ import * as postcss from 'postcss';
 import { formatDistanceToNow } from 'date-fns';
 
 import { StyleWithoutUrl } from '@stylebot/types';
-import { ToggleSwitch, IconButton, TextBlock, SButton, ConfirmDialog } from '@stylebot/components';
+import { ToggleSwitch, IconButton, SText, SButton, ConfirmDialog } from '@stylebot/components';
 import { ChevronLeftIcon } from '@stylebot/icons';
 
 import StyleRowMenu from './StyleRowMenu.vue';
@@ -89,7 +89,7 @@ export default Vue.extend({
     ToggleSwitch,
     ChevronLeftIcon,
     IconButton,
-    TextBlock,
+    SText,
     SButton,
     ConfirmDialog,
     StyleRowMenu,

--- a/src/options/components/sync/TheGoogleDriveSync.vue
+++ b/src/options/components/sync/TheGoogleDriveSync.vue
@@ -3,11 +3,11 @@
     <div class="text">
       <heading as="h2" size="sm">Google Drive</heading>
 
-      <text-block v-if="!googleDriveSyncEnabled" size="caption" variant="muted" class="description">
+      <s-text v-if="!googleDriveSyncEnabled" size="caption" variant="muted" class="description">
         Not connected. Styles stay on this computer only.
-      </text-block>
+      </s-text>
 
-      <text-block v-else size="caption" variant="muted" class="description">
+      <s-text v-else size="caption" variant="muted" class="description">
         {{ t('synced_at_time', [googleDriveSyncLastModifiedTime]) }}
         <template v-if="syncInProgress"> · {{ t('sync_in_progress') }}</template>
         <template v-if="googleDriveSyncViewLink">
@@ -16,7 +16,7 @@
           ·
           <a :href="googleDriveSyncDownloadLink" target="_blank">{{ t('download_synced_file') }}</a>
         </template>
-      </text-block>
+      </s-text>
     </div>
 
     <s-button v-if="googleDriveSyncEnabled" :disabled="syncInProgress" @click="syncWithGoogleDrive">
@@ -37,7 +37,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { formatDistanceToNow } from 'date-fns';
-import { Heading, TextBlock, SButton } from '@stylebot/components';
+import { Heading, SText, SButton } from '@stylebot/components';
 import { ArrowRepeatIcon } from '@stylebot/icons';
 
 export default Vue.extend({
@@ -47,7 +47,7 @@ export default Vue.extend({
     SButton,
     ArrowRepeatIcon,
     Heading,
-    TextBlock,
+    SText,
   },
 
   data(): {

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -9,9 +9,9 @@
 
       <div class="popup-divider" />
 
-      <text-block variant="muted" class="popup-restricted-message">
+      <s-text variant="muted" class="popup-restricted-message">
         {{ t('restricted_page_description') }}
-      </text-block>
+      </s-text>
 
       <div class="popup-divider" />
 
@@ -31,9 +31,9 @@
       />
       <div v-else class="popup-header">
         <heading as="h1" size="sm" class="popup-header-domain">{{ domain }}</heading>
-        <text-block size="caption" variant="muted">
+        <s-text size="caption" variant="muted">
           {{ t('no_style_saved_for_site') }}
-        </text-block>
+        </s-text>
       </div>
 
       <div class="popup-divider" />
@@ -75,7 +75,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { Heading, TextBlock } from '@stylebot/components';
+import { Heading, SText } from '@stylebot/components';
 
 import StyleComponent from './components/Style.vue';
 import SettingsButton from './components/SettingsButton.vue';
@@ -104,7 +104,7 @@ export default Vue.extend({
 
   components: {
     Heading,
-    TextBlock,
+    SText,
     SettingsButton,
     StyleComponent,
     ToggleStylebot,

--- a/src/popup/components/notifications/ReleaseNotification.vue
+++ b/src/popup/components/notifications/ReleaseNotification.vue
@@ -9,11 +9,11 @@
   >
     <span class="release-dot" />
 
-    <text-block class="release-text">
+    <s-text class="release-text">
       {{ t('new_in_version', [version]) }}
       <span class="release-sep">—</span>
       <span class="release-link">{{ t('see_what_changed') }}</span>
-    </text-block>
+    </s-text>
 
     <icon-button class="release-dismiss" :title="t('hide')" @click="dismiss">
       <x-icon :size="22" />
@@ -32,7 +32,7 @@ import {
 
 import { onEnterOrSpace } from '../../utils';
 import { XIcon } from '@stylebot/icons';
-import { IconButton, TextBlock } from '@stylebot/components';
+import { IconButton, SText } from '@stylebot/components';
 
 export default Vue.extend({
   name: 'ReleaseNotification',
@@ -40,7 +40,7 @@ export default Vue.extend({
   components: {
     XIcon,
     IconButton,
-    TextBlock,
+    SText,
   },
 
   data(): {

--- a/src/readability/components/dock/ShortcutMenu.vue
+++ b/src/readability/components/dock/ShortcutMenu.vue
@@ -9,13 +9,13 @@
           </span>
           <button type="button" class="cancel" @click="cancelRecording">{{ t('cancel') }}</button>
         </div>
-        <text-block size="caption" variant="muted" class="helper">
+        <s-text size="caption" variant="muted" class="helper">
           {{ t('press_key_to_finish') }}
           <template v-if="hasValue">
             {{ t('esc_keeps') }} <span class="chip chip-inline"><shortcut-kbd :value="value" /></span>
           </template>
           <template v-else>{{ t('esc_cancels') }}</template>
-        </text-block>
+        </s-text>
       </div>
 
       <div v-else-if="hasValue" class="content">
@@ -23,7 +23,7 @@
           <div class="title">{{ t('readability_shortcut') }}</div>
           <shortcut-chip :value="value" />
         </div>
-        <text-block size="caption" variant="muted" class="desc">{{ t('readability_shortcut_description') }}</text-block>
+        <s-text size="caption" variant="muted" class="desc">{{ t('readability_shortcut_description') }}</s-text>
         <div class="divider" />
         <button type="button" class="row" @click="startRecording">{{ t('change_shortcut') }}</button>
         <button type="button" class="row danger" @click="remove">{{ t('remove') }}</button>
@@ -42,7 +42,7 @@
             <icon-x />
           </button>
         </div>
-        <text-block size="caption" variant="muted" class="desc">{{ t('readability_shortcut_description') }}</text-block>
+        <s-text size="caption" variant="muted" class="desc">{{ t('readability_shortcut_description') }}</s-text>
         <button type="button" class="record-btn" @click="startRecording">
           <icon-keyboard />
           {{ t('record_shortcut') }}
@@ -66,7 +66,7 @@ import {
   MenuBox,
   ShortcutChip,
   ShortcutKbd,
-  TextBlock,
+  SText,
 } from '@stylebot/components';
 import { IconKeyboard, IconX } from '@stylebot/icons';
 
@@ -77,7 +77,7 @@ export default Vue.extend({
     MenuBox,
     ShortcutKbd,
     ShortcutChip,
-    TextBlock,
+    SText,
     IconKeyboard,
     IconX,
   },


### PR DESCRIPTION
## Summary
- Renamed the `TextBlock` component to `SText` so it follows the same `S`-prefix convention as `SButton`
- Updated all imports, component registrations, and `<text-block>` template usages to `SText`/`<s-text>` across options, popup, readability, and shared components

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test` (227 passed)