### PR TITLE
Rename MenuBox component to SMenu

### DIFF
--- a/src/components/SMenu.vue
+++ b/src/components/SMenu.vue
@@ -8,7 +8,7 @@
 import Vue from 'vue';
 
 export default Vue.extend({
-  name: 'MenuBox',
+  name: 'SMenu',
 
   props: {
     dense: {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,7 +3,7 @@ export { default as TextBlock } from './TextBlock.vue';
 export { default as ShortcutChip } from './ShortcutChip.vue';
 export { default as ShortcutKbd } from './ShortcutKbd.vue';
 export { default as ShortcutRecorderField } from './ShortcutRecorderField.vue';
-export { default as MenuBox } from './MenuBox.vue';
+export { default as SMenu } from './SMenu.vue';
 export { default as ToggleSwitch } from './ToggleSwitch.vue';
 export { default as PillButton } from './PillButton.vue';
 export { default as IconButton } from './IconButton.vue';

--- a/src/options/components/styles/StyleRowMenu.vue
+++ b/src/options/components/styles/StyleRowMenu.vue
@@ -5,7 +5,7 @@
     </template>
 
     <template #default="{ close }">
-      <menu-box dense :min-width="200">
+      <s-menu dense :min-width="200">
         <menu-item
           class="truncate"
           @click="
@@ -36,7 +36,7 @@
         >
           Delete this site's style
         </menu-item>
-      </menu-box>
+      </s-menu>
     </template>
   </anchored-menu>
 </template>
@@ -44,7 +44,7 @@
 <script lang="ts">
 import Vue from 'vue';
 
-import { AnchoredMenu, MenuBox, MenuItem } from '@stylebot/components';
+import { AnchoredMenu, SMenu, MenuItem } from '@stylebot/components';
 import IconMenuTrigger from '../IconMenuTrigger.vue';
 
 export default Vue.extend({
@@ -53,7 +53,7 @@ export default Vue.extend({
   components: {
     AnchoredMenu,
     IconMenuTrigger,
-    MenuBox,
+    SMenu,
     MenuItem,
   },
 

--- a/src/options/components/styles/StylesBulkMenu.vue
+++ b/src/options/components/styles/StylesBulkMenu.vue
@@ -5,7 +5,7 @@
     </template>
 
     <template #default="{ close }">
-      <menu-box dense :min-width="176">
+      <s-menu dense :min-width="176">
         <menu-item
           @click="
             $emit('enable-all');
@@ -35,7 +35,7 @@
         >
           Delete all styles
         </menu-item>
-      </menu-box>
+      </s-menu>
     </template>
   </anchored-menu>
 </template>
@@ -43,7 +43,7 @@
 <script lang="ts">
 import Vue from 'vue';
 
-import { AnchoredMenu, MenuBox, MenuItem } from '@stylebot/components';
+import { AnchoredMenu, SMenu, MenuItem } from '@stylebot/components';
 import IconMenuTrigger from '../IconMenuTrigger.vue';
 
 export default Vue.extend({
@@ -52,7 +52,7 @@ export default Vue.extend({
   components: {
     AnchoredMenu,
     IconMenuTrigger,
-    MenuBox,
+    SMenu,
     MenuItem,
   },
 });

--- a/src/readability/components/dock/MoreMenu.vue
+++ b/src/readability/components/dock/MoreMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <menu-box dense :min-width="184">
+  <s-menu dense :min-width="184">
     <button class="item" @click="openShortcut">
       <icon-keyboard />
       <span class="label">{{ shortcutLabel }}</span>
@@ -17,7 +17,7 @@
       <icon-coffee />
       {{ t('donate') }}
     </button>
-  </menu-box>
+  </s-menu>
 </template>
 
 <script lang="ts">
@@ -30,14 +30,14 @@ import {
   openDonatePage,
 } from '@stylebot/utils';
 
-import { MenuBox, ShortcutChip } from '@stylebot/components';
+import { SMenu, ShortcutChip } from '@stylebot/components';
 import { IconOptions, IconFlag, IconCoffee, IconKeyboard } from '@stylebot/icons';
 
 export default Vue.extend({
   name: 'MoreMenu',
 
   components: {
-    MenuBox,
+    SMenu,
     ShortcutChip,
     IconOptions,
     IconFlag,

--- a/src/readability/components/dock/SettingsMenu.vue
+++ b/src/readability/components/dock/SettingsMenu.vue
@@ -1,5 +1,5 @@
 <template>
-  <menu-box>
+  <s-menu>
     <theme-picker :theme="theme" @pick="pickTheme" />
 
     <font-picker :font="font" @pick="pickFont" />
@@ -13,7 +13,7 @@
     <div class="reset-row">
       <button class="reset" @click="reset">{{ t('reset') }}</button>
     </div>
-  </menu-box>
+  </s-menu>
 </template>
 
 <script lang="ts">
@@ -22,7 +22,7 @@ import Vue, { PropType } from 'vue';
 import { defaultReadabilitySettings } from '@stylebot/settings';
 import { ReadabilitySettings, ReadabilityTheme } from '@stylebot/types';
 
-import { MenuBox } from '@stylebot/components';
+import { SMenu } from '@stylebot/components';
 import ThemePicker from './ThemePicker.vue';
 import FontPicker from './FontPicker.vue';
 import FontSizePicker from './FontSizePicker.vue';
@@ -33,7 +33,7 @@ export default Vue.extend({
   name: 'SettingsMenu',
 
   components: {
-    MenuBox,
+    SMenu,
     ThemePicker,
     FontPicker,
     FontSizePicker,

--- a/src/readability/components/dock/ShortcutMenu.vue
+++ b/src/readability/components/dock/ShortcutMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="root" class="menu-root" tabindex="-1" @keydown="onKeydown" @keyup="onKeyup">
-    <menu-box dense :min-width="232">
+    <s-menu dense :min-width="232">
       <div v-if="recording" class="content">
         <div class="capture-row">
           <span class="capture-field">
@@ -48,7 +48,7 @@
           {{ t('record_shortcut') }}
         </button>
       </div>
-    </menu-box>
+    </s-menu>
   </div>
 </template>
 
@@ -63,7 +63,7 @@ import {
 import { shortcutStore } from './shortcut-store';
 
 import {
-  MenuBox,
+  SMenu,
   ShortcutChip,
   ShortcutKbd,
   TextBlock,
@@ -74,7 +74,7 @@ export default Vue.extend({
   name: 'ShortcutMenu',
 
   components: {
-    MenuBox,
+    SMenu,
     ShortcutKbd,
     ShortcutChip,
     TextBlock,


### PR DESCRIPTION
## Summary
- Renamed `MenuBox` to `SMenu` (file, class name, export, all template/import usages)
- `Menu` was not usable directly: Vue 2 treats `<menu>` as a reserved native HTML tag, so a component named `Menu` would silently render as a plain `<menu>` element instead of resolving to the component. `SMenu` matches the existing `SButton` naming convention for base components.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test` (227 passed, including `ShortcutMenu.test.ts` / `MoreMenu.test.ts` which exercise the renamed component)
- [x] `yarn test:e2e` (3 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)