### PR TITLE
Use MenuItem in the readability shortcut menu

### DIFF
--- a/src/readability/components/dock/ShortcutMenu.vue
+++ b/src/readability/components/dock/ShortcutMenu.vue
@@ -25,8 +25,8 @@
         </div>
         <s-text size="caption" variant="muted" class="desc">{{ t('readability_shortcut_description') }}</s-text>
         <div class="divider" />
-        <button type="button" class="row" @click="startRecording">{{ t('change_shortcut') }}</button>
-        <button type="button" class="row danger" @click="remove">{{ t('remove') }}</button>
+        <menu-item @click="startRecording">{{ t('change_shortcut') }}</menu-item>
+        <menu-item danger @click="remove">{{ t('remove') }}</menu-item>
       </div>
 
       <div v-else class="content">
@@ -63,9 +63,10 @@ import {
 import { shortcutStore } from './shortcut-store';
 
 import {
-  SMenu,
+  MenuItem,
   ShortcutChip,
   ShortcutKbd,
+  SMenu,
   SText,
 } from '@stylebot/components';
 import { IconKeyboard, IconX } from '@stylebot/icons';
@@ -74,9 +75,10 @@ export default Vue.extend({
   name: 'ShortcutMenu',
 
   components: {
-    SMenu,
+    MenuItem,
     ShortcutKbd,
     ShortcutChip,
+    SMenu,
     SText,
     IconKeyboard,
     IconX,
@@ -293,38 +295,6 @@ export default Vue.extend({
   height: 1px;
   margin: 8px 0 4px;
   background: var(--border);
-}
-
-.row {
-  all: unset;
-  box-sizing: border-box;
-  display: block;
-  width: calc(100% + 16px);
-  margin: 0 -8px;
-  font-weight: 400;
-  font-size: 12.5px;
-  line-height: 1;
-  color: var(--foreground);
-  padding: 9px 8px;
-  border-radius: 6px;
-  cursor: pointer;
-
-  &:hover {
-    background: color-mix(in srgb, var(--foreground) 6%, transparent);
-  }
-
-  &:focus-visible {
-    outline: none;
-    box-shadow: inset 0 0 0 2px var(--link-color);
-  }
-
-  &.danger {
-    color: #d1453d;
-
-    &:hover {
-      background: rgba(209, 69, 61, 0.1);
-    }
-  }
 }
 
 .capture-row {

--- a/src/readability/components/dock/__tests__/ShortcutMenu.test.ts
+++ b/src/readability/components/dock/__tests__/ShortcutMenu.test.ts
@@ -62,7 +62,7 @@ describe('ShortcutMenu.vue', () => {
   it('capturing a key combo persists it and stops recording', async () => {
     const wrapper = mountMenu('alt+shift+r');
 
-    await wrapper.findAll('.row').at(0).trigger('click'); // "change_shortcut"
+    await wrapper.findAll('.menu-item').at(0).trigger('click'); // "change_shortcut"
     expect(shortcutStore.state.recording).toBe(true);
 
     wrapper.element.dispatchEvent(
@@ -90,7 +90,7 @@ describe('ShortcutMenu.vue', () => {
   it('clicking Remove clears the shortcut', async () => {
     const wrapper = mountMenu('alt+shift+r');
 
-    await wrapper.find('.row.danger').trigger('click');
+    await wrapper.find('.menu-item.danger').trigger('click');
 
     expect(setCommands).toHaveBeenCalledWith(expect.objectContaining({ readability: '' }));
   });


### PR DESCRIPTION
## Summary
- Replace ShortcutMenu.vue's hand-rolled `.row`/`.row.danger` buttons with the shared `MenuItem` component, matching the pattern already used in `StyleRowMenu`/`StylesBulkMenu`.
- Drop the now-dead `.row` CSS from ShortcutMenu.vue.

`MoreMenu.vue`'s icon+label+chip rows and `TheReaderDock.vue`'s mutually-exclusive menu coordination were left as-is — they don't map cleanly onto `MenuItem`'s plain-text-row design or `AnchoredMenu`'s single-trigger model without a larger redesign.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test` (227 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)