### PR TITLE
Make AnchoredMenu/ConfirmDialog shadow-DOM-safe

### DIFF
--- a/src/components/AnchoredMenu.vue
+++ b/src/components/AnchoredMenu.vue
@@ -26,7 +26,7 @@ export default Vue.extend({
   watch: {
     open(isOpen: boolean): void {
       if (isOpen) {
-        this.previouslyFocused = document.activeElement as HTMLElement | null;
+        this.previouslyFocused = this.activeElement();
         document.addEventListener('mousedown', this.onDocMousedown);
         document.addEventListener('keydown', this.onDocKeydown);
         this.$emit('open');
@@ -60,9 +60,17 @@ export default Vue.extend({
     },
 
     onDocMousedown(event: MouseEvent): void {
-      if (!this.$el.contains(event.target as Node)) {
+      // composedPath()[0], not event.target, is the true origin inside a shadow tree.
+      const origin = event.composedPath()[0];
+      if (!(origin instanceof Node && this.$el.contains(origin))) {
         this.close();
       }
+    },
+
+    activeElement(): HTMLElement | null {
+      const root = this.$el.getRootNode();
+      const active = root instanceof ShadowRoot ? root.activeElement : document.activeElement;
+      return active instanceof HTMLElement ? active : null;
     },
 
     onDocKeydown(event: KeyboardEvent): void {
@@ -82,7 +90,8 @@ export default Vue.extend({
 
       event.preventDefault();
 
-      const currentIndex = items.indexOf(document.activeElement as HTMLElement);
+      const active = this.activeElement();
+      const currentIndex = active ? items.indexOf(active) : -1;
       const delta = event.key === 'ArrowDown' ? 1 : -1;
       const nextIndex = (currentIndex + delta + items.length) % items.length;
       items[nextIndex].focus();

--- a/src/components/AnchoredMenu.vue
+++ b/src/components/AnchoredMenu.vue
@@ -60,7 +60,6 @@ export default Vue.extend({
     },
 
     onDocMousedown(event: MouseEvent): void {
-      // composedPath()[0], not event.target, is the true origin inside a shadow tree.
       const origin = event.composedPath()[0];
       if (!(origin instanceof Node && this.$el.contains(origin))) {
         this.close();

--- a/src/components/ConfirmDialog.vue
+++ b/src/components/ConfirmDialog.vue
@@ -70,7 +70,7 @@ export default Vue.extend({
   mounted() {
     document.addEventListener('keydown', this.onKeydown);
 
-    this.previouslyFocused = document.activeElement as HTMLElement | null;
+    this.previouslyFocused = this.activeElement();
 
     // Deferred a tick so it wins over the closing menu's own focus-restore,
     // which runs in the same reactivity flush and would otherwise steal it back.
@@ -97,6 +97,12 @@ export default Vue.extend({
       return Array.from(card.querySelectorAll<HTMLElement>('button, a[href], [tabindex]'));
     },
 
+    activeElement(): HTMLElement | null {
+      const root = this.$el.getRootNode();
+      const active = root instanceof ShadowRoot ? root.activeElement : document.activeElement;
+      return active instanceof HTMLElement ? active : null;
+    },
+
     onKeydown(event: KeyboardEvent): void {
       if (event.key === 'Escape') {
         this.$emit('cancel');
@@ -116,11 +122,12 @@ export default Vue.extend({
 
       const first = focusable[0];
       const last = focusable[focusable.length - 1];
+      const active = this.activeElement();
 
-      if (event.shiftKey && document.activeElement === first) {
+      if (event.shiftKey && active === first) {
         event.preventDefault();
         last.focus();
-      } else if (!event.shiftKey && document.activeElement === last) {
+      } else if (!event.shiftKey && active === last) {
         event.preventDefault();
         first.focus();
       }


### PR DESCRIPTION
## Summary
- Part of the editor UI redesign (see #worktree-editor-ui-redesign). The editor mounts inside a shadow root, and reusing `AnchoredMenu`/`ConfirmDialog` there requires them to be shadow-DOM-safe first.
- `event.target` and `document.activeElement` get retargeted to the shadow host (not the real element) for listeners registered outside a shadow tree, which silently breaks outside-click-to-close, arrow-key nav, and Tab focus-trapping for any consumer mounted in a shadow root.
- Fixed via `event.composedPath()[0]` and a shadow-root-aware `activeElement()` helper (using `instanceof` narrowing instead of type casts). No behavior change for existing non-shadow-DOM consumers (popup, options) — `composedPath()[0]` equals `event.target` whenever no shadow boundary is crossed.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test` (227 passed)
- [ ] Manually verify popup/options menus and the delete-style confirm dialog still open/close/focus-trap correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)