### PR TITLE
Editor theme foundation: ThemeProvider + dark mode scaffolding

### DIFF
--- a/src/components/ThemeProvider.vue
+++ b/src/components/ThemeProvider.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="theme-provider"><slot /></div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
+  name: 'ThemeProvider',
+});
+</script>
+
+<style lang="scss" scoped>
+.theme-provider {
+  color-scheme: light dark;
+
+  --background: #fff;
+  --foreground: #191b1f;
+  --muted-foreground: #767676;
+  --border: #e9eaee;
+  --accent: #f2f3f6;
+  --active: #eceef2;
+
+  --primary: #2a5fd6;
+
+  --input: #dfe1e6;
+  --icon-foreground: #6a7180;
+
+  --info: #eef3ff;
+  --info-border: #dbe4fb;
+
+  --danger: #b3261e;
+  --danger-background: #fdf1f0;
+  --danger-border: #f6cfcb;
+
+  --ring: var(--primary);
+}
+
+@media (prefers-color-scheme: dark) {
+  .theme-provider {
+    --background: #1c1d21;
+    --foreground: #eceef2;
+    --muted-foreground: #7d838f;
+    --border: #2c2e34;
+    --accent: #26282e;
+    --active: #2b2d34;
+
+    --primary: #4d80f0;
+
+    --input: #34363d;
+    --icon-foreground: #9aa1ae;
+
+    --info: #1f2740;
+    --info-border: #2b3654;
+
+    --danger: #f2726a;
+    --danger-background: #3a2220;
+    --danger-border: #4a2b28;
+  }
+}
+</style>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,3 +11,4 @@ export { default as SButton } from './SButton.vue';
 export { default as AnchoredMenu } from './AnchoredMenu.vue';
 export { default as MenuItem } from './MenuItem.vue';
 export { default as ConfirmDialog } from './ConfirmDialog.vue';
+export { default as ThemeProvider } from './ThemeProvider.vue';

--- a/src/editor/components/EditorThemeProvider.vue
+++ b/src/editor/components/EditorThemeProvider.vue
@@ -1,0 +1,25 @@
+<template>
+  <theme-provider class="editor-theme-provider"><slot /></theme-provider>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { ThemeProvider } from '@stylebot/components';
+
+export default Vue.extend({
+  name: 'EditorThemeProvider',
+
+  components: {
+    ThemeProvider,
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.editor-theme-provider {
+  --box-model-margin: rgb(255 155 0 / 30%);
+  --box-model-border: rgb(255 200 50 / 30%);
+  --box-model-padding: rgb(77 200 0 / 30%);
+  --box-model-content: rgb(120 170 210 / 70%);
+}
+</style>

--- a/src/editor/components/TheStylebot.vue
+++ b/src/editor/components/TheStylebot.vue
@@ -59,9 +59,9 @@ export default Vue.extend({
 .stylebot {
   top: 0;
   padding: 0;
-  color: #000;
+  color: var(--foreground);
   line-height: 20px;
-  background: #fff;
+  background: var(--background);
 }
 
 .stylebot-body {

--- a/src/editor/components/TheStylebotApp.vue
+++ b/src/editor/components/TheStylebotApp.vue
@@ -1,15 +1,16 @@
 <template>
-  <div class="stylebot-app">
+  <editor-theme-provider class="stylebot-app">
     <the-stylebot v-if="visible" />
     <the-keyboard-shortcuts />
     <the-help-dialog v-if="help" />
-  </div>
+  </editor-theme-provider>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
 import { StylebotCommands } from '@stylebot/types';
 
+import EditorThemeProvider from './EditorThemeProvider.vue';
 import TheStylebot from './TheStylebot.vue';
 import TheHelpDialog from './shortcuts/TheHelpDialog.vue';
 import TheKeyboardShortcuts from './shortcuts/TheKeyboardShortcuts.vue';
@@ -18,6 +19,7 @@ export default Vue.extend({
   name: 'App',
 
   components: {
+    EditorThemeProvider,
     TheStylebot,
     TheHelpDialog,
     TheKeyboardShortcuts,


### PR DESCRIPTION
## Summary
- Part of the editor UI redesign. Lays the theme/dark-mode foundation without touching any bootstrap-vue-dependent component yet — those conversions are later PRs in this stack.
- Adds `ThemeProvider` (`src/components`), a shared component carrying the same CSS custom properties as `src/styles/theme.scss` (`--background`, `--foreground`, `--primary`, etc., with a `prefers-color-scheme: dark` variant), but scoped to a wrapper element instead of `:root`. The editor mounts inside a shadow root, where `:root` never matches anything — readability already proved the wrapper-class pattern works there.
- Adds `EditorThemeProvider` (editor-local), which layers the box-model diagram's highlight-overlay color tokens on top of `ThemeProvider`.
- `TheStylebotApp.vue` now mounts through `EditorThemeProvider`, and `TheStylebot.vue`'s root color/background read from the new variables — first end-to-end proof the theme and dark-mode media query actually apply inside the editor's shadow root.
- Popup/options intentionally **not** touched: they read theme vars on `<body>`, an ancestor of where Vue mounts, so wiring them onto a wrapping `ThemeProvider` needs its own look at that dependency rather than folding it into this editor-focused pass.
- Everything else in the editor is untouched and still runs on bootstrap-vue with hardcoded colors — that conversion happens component-by-component in the next PRs in this stack.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test` (227 passed)
- [x] `yarn build`
- [x] `yarn test:e2e` (3 passed, including opening the editor in the current tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)