### PR TITLE
Disable inline sourcemaps in production builds

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,7 +51,8 @@ const config = {
   stats: 'errors-only',
   mode: process.env.NODE_ENV,
   context: `${__dirname}/src`,
-  devtool: 'inline-source-map',
+  // Inline sourcemaps in production bloat every content script (see #890).
+  devtool: process.env.NODE_ENV === 'production' ? false : 'inline-source-map',
 
   optimization: {
     minimize: process.env.NODE_ENV === 'production',


### PR DESCRIPTION
## Summary
- `webpack.config.js` set `devtool: 'inline-source-map'` unconditionally, so the production Chrome/Edge build embedded multi-MB base64 sourcemaps directly in every content script (93-97% of the shipped file size in `inject-css/index.js` and `editor/index.js`)
- `inject-css` runs with `all_frames: true` on `<all_urls>` at `document_start`, so this multi-MB blob loads into every single iframe on every page — DevTools has to decode/parse it whenever open, which matches the reported freeze/slowness
- Now `devtool` is `false` in production (still `inline-source-map` for `yarn watch`/dev, which still needs MV3-CSP-compatible sourcemaps for debugging)

Measured with a local `yarn build`:
| File | Before | After |
|---|---|---|
| `dist/inject-css/index.js` | 3.75 MB | 605 KB |
| `dist/editor/index.js` | 8.74 MB | 1.59 MB |

Fixes #890

## Test plan
- [x] `yarn build` succeeds
- [x] Verified rebuilt `dist/inject-css/index.js` and `dist/editor/index.js` no longer contain embedded sourcemap data (only harmless `sourceMappingURL` string literals from bundled PostCSS library code)
- [ ] Smoke test the built extension in Edge on a page with several iframes, with DevTools open, to confirm no more freeze

🤖 Generated with [Claude Code](https://claude.com/claude-code)